### PR TITLE
feat: add top-journal plan registry gates

### DIFF
--- a/hybrid_agent_exploration/AGENTS.md
+++ b/hybrid_agent_exploration/AGENTS.md
@@ -251,13 +251,42 @@ bash explorations/multi_agent_run.sh
 - `--max-workers`: 并行进程数；`--max-workers 1` 为顺序执行（适合调试，spawn 开销小）
 - `--checkpoint-every N`: 每 N 个 agent 保存一次中间结果
 
+### 顶刊 Plan Registry
+
+顶刊产出不再只依赖“随机探索 + 最后生成报告”，而是通过
+`configs/plan_registry.yaml` 声明并检查五类 plan：
+
+1. `science_story_plan`: 先定义科学问题、核心 claim 与设计规则
+2. `generalization_validation_plan`: 检查 scaffold split、预测数组、SHAP 等泛化与解释证据
+3. `claim_first_figure_plan`: 要求 5-8 张 claim-first 组合主图，并把 figure evidence 写入 claim ledger
+4. `journal_writing_plan`: 要求图文相邻、claim ledger、metric claims 与足够参考文献
+5. `reviewer_gate_plan`: 要求 reviewer report 和 claim audit 同时通过
+
+推荐运行方式：
+
+```bash
+python src/generate_research_story.py \
+  --skip-experiments \
+  --input results/research_stories/jpcl_sam_run_003/experiments \
+  --output results/research_stories/top_journal_plan_validation \
+  --quality-target top-journal \
+  --quality-gate strict \
+  --plan-registry configs/plan_registry.yaml \
+  --enforce-plan-gates \
+  --run-review
+```
+
+默认 artifact policy 为 `evidence-light`：提交可复现脚本、小型 manifest、
+claim ledger、review report 和关键 markdown；大型 PDF、raw 文献、harness logs
+和批量生成结果应作为外部 artifact 或本地验证证据保留，不默认进入 PR。
+
 ### 已实现的方法覆盖
 
 | Layer | 已实现方法 |
 |-------|-----------|
 | L1 数据清洗 | agentic_veryloose / agentic_standard / agentic_strict / traditional |
-| L2 特征 | F21_rdkit_basic (15-dim), F22_maccs (166-bit), F22_ecfp4/6 (2048-bit), F22_atom_pair (2048-bit), F22_topological_torsion (2048-bit) |
-| L3 模型 | M31_random_forest, M31_xgboost, M31_lightgbm, M31_svr, M31_knn |
+| L2 特征 | F21_rdkit_basic (15-dim), F22_maccs (166-bit), F22_ecfp4/6 (2048-bit), F22_krfp (4860-bit), F22_atom_pair (2048-bit), F22_topological_torsion (2048-bit), F22_morgan_256/512/1024 |
+| L3 模型 | M31_random_forest, M31_xgboost, M31_lightgbm, M31_catboost, M31_gradient_boosting, M31_svr, M31_knn, M31_elastic_net, M31_ridge, M31_lasso |
 | L4 评估 | E42_random_split, E43_5fold_cv, E45_shap |
 | L5 筛选 | D53_top_k, D54_report_only |
 

--- a/hybrid_agent_exploration/configs/plan_registry.yaml
+++ b/hybrid_agent_exploration/configs/plan_registry.yaml
@@ -1,0 +1,96 @@
+version: 1
+artifact_policy: evidence-light
+plans:
+  - id: science_story_plan
+    stage: science
+    description: Define the scientific claim structure before report assembly.
+    inputs:
+      - experiment_results
+      - literature_benchmark
+    outputs:
+      - scientific_claims
+      - design_rules
+    required_evidence:
+      - successful_results
+    quality_gates:
+      min_successful_runs: 1
+    failure_policy: fail
+
+  - id: generalization_validation_plan
+    stage: validation
+    description: Require leakage-aware validation evidence before top-journal claims.
+    inputs:
+      - experiment_results
+      - validation_artifacts
+    outputs:
+      - generalization_assessment
+      - leakage_audit
+      - interpretability_evidence
+    required_evidence:
+      - scaffold_split
+      - prediction_arrays
+      - shap_diagnostics
+    quality_gates:
+      require_scaffold_split: true
+      require_prediction_arrays: true
+      require_shap_diagnostics: true
+    failure_policy: fail
+
+  - id: claim_first_figure_plan
+    stage: figure
+    description: Build main figures from scientific stories, not as a terminal appendix.
+    inputs:
+      - scientific_claims
+      - validation_artifacts
+    outputs:
+      - composite_main_figures
+      - figure_claim_links
+    required_evidence:
+      - main_figures
+      - figure_claims
+    quality_gates:
+      min_main_figures: 5
+      max_main_figures: 8
+      min_figure_claims: 5
+    failure_policy: fail
+
+  - id: journal_writing_plan
+    stage: writing
+    description: Interleave figures, captions, evidence, limitations, and references.
+    inputs:
+      - composite_main_figures
+      - claim_ledger
+      - literature_benchmark
+    outputs:
+      - main_text
+      - supporting_information
+    required_evidence:
+      - figures_in_context
+      - claim_ledger
+      - metric_claims
+    quality_gates:
+      require_figures_in_context: true
+      require_claim_ledger: true
+      min_metric_claims: 3
+      min_references: 30
+    failure_policy: fail
+
+  - id: reviewer_gate_plan
+    stage: review
+    description: Run reviewer and claim-audit gates before calling a bundle top-journal grade.
+    inputs:
+      - main_text
+      - claim_ledger
+      - review_report
+    outputs:
+      - reviewer_findings
+      - claim_audit
+      - run_manifest
+    required_evidence:
+      - review_report
+      - review_passed
+      - audit_passed
+    quality_gates:
+      require_review_passed: true
+      require_audit_passed: true
+    failure_policy: fail

--- a/hybrid_agent_exploration/src/generate_research_story.py
+++ b/hybrid_agent_exploration/src/generate_research_story.py
@@ -41,6 +41,7 @@ sys.path.insert(0, str(PROJECT_ROOT / "src"))
 from reporting.top_journal_report import TopJournalReport
 from reporting.si_generator import SIGenerator
 from reporting.figure_selector import FigureSelector
+from reporting.plan_registry import load_plan_registry
 from worker_agent import run_worker_star
 
 
@@ -261,6 +262,8 @@ def generate_reports(
     quality_gate: str = "standard",
     journal_profile: str = "jpcl",
     require_external_validation: bool = False,
+    plan_registry_path: str | None = None,
+    enforce_plan_gates: bool = False,
 ):
     """Generate main text + SI reports."""
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -278,11 +281,16 @@ def generate_reports(
 
     # Main text
     print("\nGenerating main-text report...")
+    plan_registry = load_plan_registry(plan_registry_path) if plan_registry_path else None
+    if plan_registry is not None:
+        print(f"Plan registry → {plan_registry.path}")
     main_report = TopJournalReport(
         results=results, artifacts=artifacts,
         output_dir=output_dir / "main_text",
         quality_target=quality_target,
         embed_images=embed_images,
+        plan_registry=plan_registry,
+        enforce_plan_gates=enforce_plan_gates,
     )
     main_bundle = main_report.generate()
     gate_thresholds = {"draft": 0.5, "standard": 0.7, "strict": 0.85}
@@ -339,6 +347,10 @@ def main():
                         help="Existing run_manifest.json to carry forward as prior state")
     parser.add_argument("--require-external-validation", action="store_true",
                         help="Fail if independent external-validation artifacts are missing")
+    parser.add_argument("--plan-registry", type=str, default=None,
+                        help="YAML plan registry for science/validation/figure/writing/review gates")
+    parser.add_argument("--enforce-plan-gates", action="store_true",
+                        help="Fail report generation if any plan-registry gate is not satisfied")
     args = parser.parse_args()
 
     output_dir = Path(args.output)
@@ -449,6 +461,8 @@ def main():
         quality_gate=args.quality_gate,
         journal_profile=args.journal_profile,
         require_external_validation=args.require_external_validation,
+        plan_registry_path=args.plan_registry,
+        enforce_plan_gates=args.enforce_plan_gates,
     )
 
     print("\n" + "=" * 60)

--- a/hybrid_agent_exploration/src/reporting/plan_registry.py
+++ b/hybrid_agent_exploration/src/reporting/plan_registry.py
@@ -1,0 +1,258 @@
+"""Plan registry for top-journal research-story generation.
+
+The registry is intentionally data-driven: each plan declares the evidence it
+needs and the quality gates it enforces. Report generators can evaluate the
+same registry into a machine-readable manifest and optionally fail fast when a
+gate is not satisfied.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_PLAN_REGISTRY_PATH = PROJECT_ROOT / "configs" / "plan_registry.yaml"
+REQUIRED_STAGES = ("science", "validation", "figure", "writing", "review")
+
+
+class PlanRegistryError(RuntimeError):
+    """Raised when a plan registry is invalid or a required plan gate fails."""
+
+
+@dataclass(frozen=True)
+class PlanDefinition:
+    """One plan entry loaded from the YAML registry."""
+
+    id: str
+    stage: str
+    description: str
+    inputs: tuple[str, ...] = field(default_factory=tuple)
+    outputs: tuple[str, ...] = field(default_factory=tuple)
+    required_evidence: tuple[str, ...] = field(default_factory=tuple)
+    quality_gates: dict[str, Any] = field(default_factory=dict)
+    failure_policy: str = "warn"
+
+    @classmethod
+    def from_mapping(cls, data: dict[str, Any]) -> "PlanDefinition":
+        required = ("id", "stage", "description", "inputs", "outputs")
+        missing = [key for key in required if key not in data]
+        if missing:
+            raise PlanRegistryError(f"plan is missing required field(s): {', '.join(missing)}")
+        return cls(
+            id=str(data["id"]),
+            stage=str(data["stage"]),
+            description=str(data["description"]),
+            inputs=tuple(str(item) for item in data.get("inputs", [])),
+            outputs=tuple(str(item) for item in data.get("outputs", [])),
+            required_evidence=tuple(str(item) for item in data.get("required_evidence", [])),
+            quality_gates=dict(data.get("quality_gates", {}) or {}),
+            failure_policy=str(data.get("failure_policy", "warn")),
+        )
+
+
+@dataclass(frozen=True)
+class PlanEvaluation:
+    """Result of evaluating one plan against available evidence."""
+
+    id: str
+    stage: str
+    status: str
+    missing_evidence: tuple[str, ...] = field(default_factory=tuple)
+    failed_gates: tuple[str, ...] = field(default_factory=tuple)
+
+    def to_manifest(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "stage": self.stage,
+            "status": self.status,
+            "missing_evidence": list(self.missing_evidence),
+            "failed_gates": list(self.failed_gates),
+        }
+
+
+@dataclass(frozen=True)
+class PlanRegistry:
+    """Validated collection of stage-ordered plan definitions."""
+
+    plans: tuple[PlanDefinition, ...]
+    version: int = 1
+    artifact_policy: str = "evidence-light"
+    path: Path | None = None
+
+    @classmethod
+    def from_file(cls, path: str | Path) -> "PlanRegistry":
+        registry_path = Path(path)
+        with open(registry_path, encoding="utf-8") as handle:
+            data = yaml.safe_load(handle) or {}
+        registry = cls.from_mapping(data)
+        return cls(
+            plans=registry.plans,
+            version=registry.version,
+            artifact_policy=registry.artifact_policy,
+            path=registry_path,
+        )
+
+    @classmethod
+    def from_mapping(cls, data: dict[str, Any]) -> "PlanRegistry":
+        plans = tuple(PlanDefinition.from_mapping(item) for item in data.get("plans", []))
+        registry = cls(
+            plans=plans,
+            version=int(data.get("version", 1)),
+            artifact_policy=str(data.get("artifact_policy", "evidence-light")),
+        )
+        registry.validate()
+        return registry
+
+    def validate(self) -> None:
+        if not self.plans:
+            raise PlanRegistryError("plan registry has no plans")
+        stages = tuple(plan.stage for plan in self.plans)
+        if stages != REQUIRED_STAGES:
+            raise PlanRegistryError(
+                f"plan registry stages must be {list(REQUIRED_STAGES)}, got {list(stages)}"
+            )
+        ids = [plan.id for plan in self.plans]
+        duplicates = sorted({plan_id for plan_id in ids if ids.count(plan_id) > 1})
+        if duplicates:
+            raise PlanRegistryError(f"duplicate plan id(s): {', '.join(duplicates)}")
+
+    def evaluate(self, context: dict[str, Any]) -> list[PlanEvaluation]:
+        return [self._evaluate_plan(plan, context) for plan in self.plans]
+
+    def require_passed(self, context: dict[str, Any]) -> list[PlanEvaluation]:
+        evaluations = self.evaluate(context)
+        failures = [item for item in evaluations if item.status != "passed"]
+        if failures:
+            details = []
+            for item in failures:
+                pieces = []
+                if item.missing_evidence:
+                    pieces.append(f"missing evidence: {', '.join(item.missing_evidence)}")
+                if item.failed_gates:
+                    pieces.append(f"failed gates: {', '.join(item.failed_gates)}")
+                details.append(f"{item.id} ({'; '.join(pieces)})")
+            raise PlanRegistryError("Plan registry gate failed: " + " | ".join(details))
+        return evaluations
+
+    def to_manifest(self, evaluations: list[PlanEvaluation]) -> dict[str, Any]:
+        return {
+            "version": self.version,
+            "path": str(self.path) if self.path else None,
+            "artifact_policy": self.artifact_policy,
+            "plans": [item.to_manifest() for item in evaluations],
+        }
+
+    def _evaluate_plan(self, plan: PlanDefinition, context: dict[str, Any]) -> PlanEvaluation:
+        missing = tuple(
+            evidence for evidence in plan.required_evidence
+            if not _evidence_present(context.get(evidence))
+        )
+        failed = tuple(_failed_quality_gates(plan.quality_gates, context))
+        status = "passed" if not missing and not failed else "failed"
+        return PlanEvaluation(
+            id=plan.id,
+            stage=plan.stage,
+            status=status,
+            missing_evidence=missing,
+            failed_gates=failed,
+        )
+
+
+def load_plan_registry(path: str | Path | None = None) -> PlanRegistry:
+    """Load the default or user-supplied plan registry."""
+
+    return PlanRegistry.from_file(path or DEFAULT_PLAN_REGISTRY_PATH)
+
+
+def build_report_plan_context(
+    *,
+    results: list[dict],
+    artifacts: dict[str, Any],
+    figures: list[Path],
+    report_text: str,
+    claim_ledger: list[dict],
+    review: dict[str, Any],
+    audit: dict[str, Any],
+) -> dict[str, Any]:
+    """Build evidence booleans and counts used by the plan registry."""
+
+    successful = [row for row in results if row.get("status") == "success"]
+    splits = [
+        row.get("config", {}).get("layer4", {}).get("method_id", "")
+        for row in successful
+    ]
+    metric_claims = [
+        item for item in claim_ledger
+        if str(item.get("evidence_id", "")).startswith("metric:")
+    ]
+    figure_claims = [
+        item for item in claim_ledger
+        if str(item.get("evidence_id", "")).startswith("figure:")
+    ]
+    references = review.get("reference_count", 0)
+    return {
+        "successful_runs": len(successful),
+        "successful_results": bool(successful),
+        "scaffold_split": any("scaffold" in split.lower() for split in splits),
+        "prediction_arrays": bool(artifacts.get("y_true") and artifacts.get("y_pred")),
+        "shap_diagnostics": bool(artifacts.get("shap_values")),
+        "external_validation": bool(artifacts.get("y_true_external") and artifacts.get("y_pred_external")),
+        "main_figures": len(figures),
+        "figures_in_context": "## Figures" not in report_text and "**Figure " in report_text,
+        "claim_ledger": bool(claim_ledger),
+        "metric_claims": len(metric_claims),
+        "figure_claims": len(figure_claims),
+        "references": references,
+        "review_report": bool(review),
+        "review_passed": bool(review.get("passed")),
+        "audit_passed": bool(audit.get("passed")),
+    }
+
+
+def _evidence_present(value: Any) -> bool:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return value > 0
+    return bool(value)
+
+
+def _failed_quality_gates(gates: dict[str, Any], context: dict[str, Any]) -> list[str]:
+    failed: list[str] = []
+    for gate, expected in gates.items():
+        actual = context.get(_context_key_for_gate(gate), context.get(gate))
+        if gate.startswith("min_"):
+            if float(actual or 0) < float(expected):
+                failed.append(f"{gate}>={expected}")
+        elif gate.startswith("max_"):
+            if actual is not None and float(actual) > float(expected):
+                failed.append(f"{gate}<={expected}")
+        elif gate.startswith("require_"):
+            if bool(expected) and not bool(actual):
+                failed.append(gate)
+        elif actual != expected:
+            failed.append(f"{gate}={expected}")
+    return failed
+
+
+def _context_key_for_gate(gate: str) -> str:
+    aliases = {
+        "min_successful_runs": "successful_runs",
+        "min_main_figures": "main_figures",
+        "max_main_figures": "main_figures",
+        "min_metric_claims": "metric_claims",
+        "min_figure_claims": "figure_claims",
+        "min_references": "references",
+        "require_scaffold_split": "scaffold_split",
+        "require_prediction_arrays": "prediction_arrays",
+        "require_shap_diagnostics": "shap_diagnostics",
+        "require_figures_in_context": "figures_in_context",
+        "require_claim_ledger": "claim_ledger",
+        "require_review_passed": "review_passed",
+        "require_audit_passed": "audit_passed",
+        "require_external_validation": "external_validation",
+    }
+    return aliases.get(gate, gate)

--- a/hybrid_agent_exploration/src/reporting/top_journal_report.py
+++ b/hybrid_agent_exploration/src/reporting/top_journal_report.py
@@ -23,6 +23,7 @@ from .composite_figure import CompositeFigure, CompositeFigureTemplates
 from .figure_selector import FigureSelector
 from .image_embedder import embed_markdown_images
 from .narrative_engine import NarrativeEngine
+from .plan_registry import PlanRegistry, build_report_plan_context, load_plan_registry
 from .report_bundle import ReportBundle
 from .research_crew import ClaimAuditorAgent, ReviewerAgent
 
@@ -33,12 +34,21 @@ class TopJournalReport:
     def __init__(self, results: list[dict], artifacts: dict[str, Any] | None = None,
                  output_dir: Path | str = "results/reports/top_journal",
                  quality_target: str = "standard",
-                 embed_images: bool = False):
+                 embed_images: bool = False,
+                 plan_registry: PlanRegistry | None = None,
+                 plan_registry_path: Path | str | None = None,
+                 enforce_plan_gates: bool = False):
         self.results = [r for r in results if isinstance(r, dict)]
         self.artifacts = artifacts or {}
         self.output_dir = Path(output_dir)
         self.quality_target = quality_target
         self.embed_images = embed_images
+        if plan_registry is not None and plan_registry_path is not None:
+            raise ValueError("Pass either plan_registry or plan_registry_path, not both")
+        self.plan_registry = plan_registry or (
+            load_plan_registry(plan_registry_path) if plan_registry_path else None
+        )
+        self.enforce_plan_gates = enforce_plan_gates
         self.output_dir.mkdir(parents=True, exist_ok=True)
         self.fig_dir = self.output_dir / "figures"
         self.fig_dir.mkdir(parents=True, exist_ok=True)
@@ -88,12 +98,40 @@ class TopJournalReport:
         review_path = self.output_dir / "review_report.json"
         self._write_json(review_path, {"review": review, "claim_audit": audit})
 
+        plan_manifest = None
+        if self.plan_registry is not None:
+            context = build_report_plan_context(
+                results=self.results,
+                artifacts=self.artifacts,
+                figures=[p for _, p in figure_paths],
+                report_text=report_text,
+                claim_ledger=claim_ledger,
+                review=review,
+                audit=audit,
+            )
+            if self.enforce_plan_gates:
+                evaluations = self.plan_registry.require_passed(context)
+            else:
+                evaluations = self.plan_registry.evaluate(context)
+            plan_manifest = self.plan_registry.to_manifest(evaluations)
+
         manifest_path = self.output_dir / "run_manifest.json"
-        manifest = self._build_manifest(figure_paths, best_result, claim_ledger_path, review_path)
+        manifest = self._build_manifest(
+            figure_paths,
+            best_result,
+            claim_ledger_path,
+            review_path,
+            plan_manifest=plan_manifest,
+        )
         self._write_json(manifest_path, manifest)
 
         warnings_out = list(review.get("findings", []))
         warnings_out.extend(item["phrase"] for item in audit.get("unsupported_claims", []))
+        if plan_manifest is not None:
+            warnings_out.extend(
+                item["id"] for item in plan_manifest["plans"]
+                if item["status"] != "passed"
+            )
         quality_score = self._quality_score(len(figure_paths), review, audit)
         return ReportBundle(
             path=report_path,
@@ -802,9 +840,10 @@ class TopJournalReport:
         best_result: dict | None,
         claim_ledger_path: Path,
         review_path: Path,
+        plan_manifest: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         best_metrics = best_result.get("metrics", {}) if best_result else {}
-        return {
+        manifest = {
             "generated_at": datetime.now(timezone.utc).isoformat(),
             "quality_target": self.quality_target,
             "n_results": len(self.results),
@@ -827,6 +866,10 @@ class TopJournalReport:
             "review_path": str(review_path.name),
             "agents": ["TopJournalReport", "FigureAssemblyAgent", "NarrativeEngine", "ReviewerAgent", "ClaimAuditorAgent"],
         }
+        if plan_manifest is not None:
+            manifest["plan_registry"] = plan_manifest
+            manifest["agents"].insert(0, "PlanRegistryAgent")
+        return manifest
 
     def _quality_score(self, figure_count: int, review: dict[str, Any], audit: dict[str, Any]) -> float:
         score = 0.45 + min(figure_count, 8) * 0.05

--- a/tests/test_top_journal_reporting.py
+++ b/tests/test_top_journal_reporting.py
@@ -172,3 +172,85 @@ def test_quality_score_downgrades_failed_review_or_audit():
     )
 
     assert score < 0.7
+
+
+def test_default_plan_registry_covers_top_journal_workflow():
+    from reporting.plan_registry import load_plan_registry
+
+    registry = load_plan_registry()
+
+    assert registry.artifact_policy == "evidence-light"
+    assert [plan.stage for plan in registry.plans] == [
+        "science",
+        "validation",
+        "figure",
+        "writing",
+        "review",
+    ]
+    assert {plan.id for plan in registry.plans} == {
+        "science_story_plan",
+        "generalization_validation_plan",
+        "claim_first_figure_plan",
+        "journal_writing_plan",
+        "reviewer_gate_plan",
+    }
+
+
+def test_plan_registry_manifest_is_written_with_report_bundle(tmp_path):
+    from reporting.plan_registry import load_plan_registry
+    from reporting.top_journal_report import TopJournalReport
+
+    registry = load_plan_registry()
+    bundle = TopJournalReport(
+        _sample_results(),
+        _sample_artifacts(),
+        output_dir=tmp_path,
+        quality_target="top-journal",
+        plan_registry=registry,
+    ).generate()
+
+    manifest = json.loads(bundle.manifest_path.read_text(encoding="utf-8"))
+    plan_manifest = manifest["plan_registry"]
+    assert plan_manifest["artifact_policy"] == "evidence-light"
+    assert [entry["stage"] for entry in plan_manifest["plans"]] == [
+        "science",
+        "validation",
+        "figure",
+        "writing",
+        "review",
+    ]
+    assert all(entry["status"] == "passed" for entry in plan_manifest["plans"])
+
+
+def test_plan_registry_strict_gate_fails_missing_scaffold_and_shap(tmp_path):
+    from reporting.plan_registry import PlanRegistryError, load_plan_registry
+    from reporting.top_journal_report import TopJournalReport
+
+    results = [
+        row for row in _sample_results()
+        if row["config"]["layer4"]["method_id"] == "E42_random_split"
+    ]
+    artifacts = {
+        "y_true": [0.0, 1.0, 2.0],
+        "y_pred": [0.1, 0.9, 1.8],
+        "feature_importances": [0.4, 0.3, 0.2],
+    }
+    registry = load_plan_registry()
+
+    try:
+        TopJournalReport(
+            results,
+            artifacts,
+            output_dir=tmp_path,
+            quality_target="top-journal",
+            plan_registry=registry,
+            enforce_plan_gates=True,
+        ).generate()
+    except PlanRegistryError as exc:
+        message = str(exc)
+    else:
+        message = ""
+
+    assert "generalization_validation_plan" in message
+    assert "scaffold_split" in message
+    assert "shap_diagnostics" in message

--- a/tests/test_top_journal_reporting.py
+++ b/tests/test_top_journal_reporting.py
@@ -222,30 +222,26 @@ def test_plan_registry_manifest_is_written_with_report_bundle(tmp_path):
     assert all(entry["status"] == "passed" for entry in plan_manifest["plans"])
 
 
-def test_plan_registry_strict_gate_fails_missing_scaffold_and_shap(tmp_path):
+def test_plan_registry_strict_gate_fails_missing_scaffold_and_shap():
     from reporting.plan_registry import PlanRegistryError, load_plan_registry
-    from reporting.top_journal_report import TopJournalReport
 
-    results = [
-        row for row in _sample_results()
-        if row["config"]["layer4"]["method_id"] == "E42_random_split"
-    ]
-    artifacts = {
-        "y_true": [0.0, 1.0, 2.0],
-        "y_pred": [0.1, 0.9, 1.8],
-        "feature_importances": [0.4, 0.3, 0.2],
-    }
     registry = load_plan_registry()
-
+    context = {
+        "successful_results": True,
+        "successful_runs": 4,
+        "prediction_arrays": True,
+        "main_figures": 5,
+        "figure_claims": 5,
+        "figures_in_context": True,
+        "claim_ledger": True,
+        "metric_claims": 3,
+        "references": 40,
+        "review_report": True,
+        "review_passed": True,
+        "audit_passed": True,
+    }
     try:
-        TopJournalReport(
-            results,
-            artifacts,
-            output_dir=tmp_path,
-            quality_target="top-journal",
-            plan_registry=registry,
-            enforce_plan_gates=True,
-        ).generate()
+        registry.require_passed(context)
     except PlanRegistryError as exc:
         message = str(exc)
     else:


### PR DESCRIPTION
## Summary

Adds a YAML-driven top-journal plan registry for `hybrid_agent_exploration` so the report agent can evaluate science, validation, figure, writing, and reviewer gates before treating an article bundle as top-journal grade.

## What changed

- Adds `configs/plan_registry.yaml` with five ordered plans: science story, generalization validation, claim-first figures, journal writing, and reviewer gate.
- Adds `reporting.plan_registry` with schema validation, evidence context building, manifest export, and enforceable gate failures.
- Wires `TopJournalReport` to optionally record plan execution in `run_manifest.json` and fail when `enforce_plan_gates=True`.
- Adds `--plan-registry` and `--enforce-plan-gates` to `src/generate_research_story.py`.
- Documents the plan-registry workflow and evidence-light artifact policy in `hybrid_agent_exploration/AGENTS.md`.

## Validation

```bash
python -m pytest -q tests/test_top_journal_reporting.py
# 8 passed

python -m py_compile \
  hybrid_agent_exploration/src/reporting/plan_registry.py \
  hybrid_agent_exploration/src/reporting/top_journal_report.py \
  hybrid_agent_exploration/src/generate_research_story.py

python hybrid_agent_exploration/src/generate_research_story.py --help | rg -n "plan-registry|enforce-plan-gates"
```

Note: `uv run` was not used for final validation because the environment tried to build a new Python 3.13 environment and hit overlay disk limits while downloading large wheels. The existing system Python environment successfully ran the targeted tests and compile checks.