### PR TITLE
chore: ignore local git worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ Desktop.ini
 
 # ===== Claude Code =====
 .claude/
+.worktrees/
 
 # ===== Large HTML (dashboard) =====
 dashboard.html


### PR DESCRIPTION
## Summary

Adds `.worktrees/` to `.gitignore` so local Git worktree checkouts do not appear as untracked PR content from the root checkout.

## Validation

```bash
git check-ignore -v .worktrees/example
# .gitignore:64:.worktrees/ .worktrees/example
```

This is a git hygiene-only change; no runtime code changed.