### PR TITLE
feat: add strict real data authenticity checker

### DIFF
--- a/hybrid_agent_exploration/src/harness/authenticity.py
+++ b/hybrid_agent_exploration/src/harness/authenticity.py
@@ -1,0 +1,332 @@
+"""Real-data authenticity checks for PSC additive datasets.
+
+The checker is strict by default: records must have traceable literature and
+molecule evidence before they can enter the default training set. External
+verification is injected through resolver callables so tests stay deterministic
+and production code can use Crossref, PubChem, or MCP-backed resolvers.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass, field
+from difflib import SequenceMatcher
+from typing import Any, Callable, Iterable
+
+from .guardrail import Guardrail
+
+
+ReferenceVerifier = Callable[[str], "ReferenceEvidence | None"]
+MoleculeVerifier = Callable[[dict[str, Any]], "MoleculeEvidence | None"]
+
+
+@dataclass(frozen=True)
+class ReferenceEvidence:
+    """External or local evidence proving a publication record exists."""
+
+    doi: str
+    title: str
+    year: int | None = None
+    journal: str | None = None
+    source: str = "reference"
+    url: str | None = None
+
+    def to_source(self) -> dict[str, Any]:
+        return {
+            "kind": "reference",
+            "source": self.source,
+            "doi": self.doi,
+            "title": self.title,
+            "year": self.year,
+            "journal": self.journal,
+            "url": self.url,
+        }
+
+
+@dataclass(frozen=True)
+class MoleculeEvidence:
+    """External or local evidence proving a molecule identity exists."""
+
+    smiles: str
+    pubchem_id: str | None = None
+    cas_number: str | None = None
+    source: str = "molecule"
+    url: str | None = None
+
+    def to_source(self) -> dict[str, Any]:
+        return {
+            "kind": "molecule",
+            "source": self.source,
+            "smiles": self.smiles,
+            "pubchem_id": self.pubchem_id,
+            "cas_number": self.cas_number,
+            "url": self.url,
+        }
+
+
+@dataclass(frozen=True)
+class VerificationResult:
+    """Authenticity decision for one input row."""
+
+    status: str
+    reasons: list[str] = field(default_factory=list)
+    sources: list[dict[str, Any]] = field(default_factory=list)
+    normalized: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def is_verified(self) -> bool:
+        return self.status == "verified"
+
+
+@dataclass(frozen=True)
+class VerificationSplit:
+    """Strict split between model-ready rows and quarantined rows."""
+
+    verified: list[dict[str, Any]]
+    quarantine: list[dict[str, Any]]
+
+
+class RealDataAuthenticator:
+    """Validate literature, molecule identity, and JV-derived target values."""
+
+    def __init__(
+        self,
+        reference_verifier: ReferenceVerifier | None = None,
+        molecule_verifier: MoleculeVerifier | None = None,
+        *,
+        strict: bool = True,
+        delta_tolerance: float = 0.05,
+    ) -> None:
+        self.reference_verifier = reference_verifier
+        self.molecule_verifier = molecule_verifier
+        self.strict = strict
+        self.delta_tolerance = delta_tolerance
+        self.guardrail = Guardrail()
+
+    def verify_record(self, record: dict[str, Any]) -> VerificationResult:
+        reasons: list[str] = []
+        sources: list[dict[str, Any]] = []
+        normalized = dict(record)
+
+        doi = _clean_text(record.get("doi"))
+        title = _clean_text(record.get("title"))
+        smiles = _clean_text(record.get("smiles"))
+
+        if not doi:
+            reasons.append("missing_doi")
+        if not title:
+            reasons.append("missing_title")
+
+        if smiles:
+            if not self.guardrail.validate_smiles(smiles):
+                reasons.append("invalid_smiles")
+        else:
+            reasons.append("missing_smiles")
+
+        reference = self.reference_verifier(doi) if doi and self.reference_verifier else None
+        if reference:
+            sources.append(reference.to_source())
+            if title and not _titles_match(title, reference.title):
+                reasons.append("reference_title_mismatch")
+            record_year = _extract_year(record)
+            if record_year is not None and reference.year is not None and record_year != reference.year:
+                reasons.append("reference_year_mismatch")
+        elif self.strict:
+            reasons.append("missing_reference_evidence")
+
+        molecule = self.molecule_verifier(record) if self.molecule_verifier else None
+        if molecule:
+            sources.append(molecule.to_source())
+            if smiles and molecule.smiles and not _smiles_match(smiles, molecule.smiles):
+                reasons.append("molecule_smiles_mismatch")
+            pubchem_id = _clean_text(record.get("pubchem_id"))
+            if pubchem_id and molecule.pubchem_id and pubchem_id != str(molecule.pubchem_id):
+                reasons.append("pubchem_id_mismatch")
+            cas_number = _clean_text(record.get("cas_number"))
+            if cas_number and molecule.cas_number and cas_number != str(molecule.cas_number):
+                reasons.append("cas_number_mismatch")
+        elif self.strict:
+            reasons.append("missing_molecule_evidence")
+
+        self._validate_jv_values(record, reasons, normalized)
+
+        status = "verified" if not reasons else "quarantine"
+        normalized["verification_status"] = status
+        if reasons:
+            normalized["quarantine_reason"] = ";".join(reasons)
+        normalized["verification_sources"] = sources
+
+        return VerificationResult(status=status, reasons=reasons, sources=sources, normalized=normalized)
+
+    def split_records(self, records: Iterable[dict[str, Any]]) -> VerificationSplit:
+        verified: list[dict[str, Any]] = []
+        quarantine: list[dict[str, Any]] = []
+        for record in records:
+            result = self.verify_record(record)
+            if result.is_verified:
+                verified.append(result.normalized)
+            else:
+                quarantine.append(result.normalized)
+        return VerificationSplit(verified=verified, quarantine=quarantine)
+
+    def _validate_jv_values(
+        self,
+        record: dict[str, Any],
+        reasons: list[str],
+        normalized: dict[str, Any],
+    ) -> None:
+        baseline = _to_float(record.get("jv_reverse_scan_pce_without_modulator"))
+        treated = _to_float(record.get("jv_reverse_scan_pce"))
+        delta = _to_float(record.get("delta_pce"))
+
+        if baseline is None:
+            reasons.append("missing_baseline_pce")
+        elif not self.guardrail.validate_pce(baseline):
+            reasons.append("baseline_pce_out_of_bounds")
+        else:
+            normalized["jv_reverse_scan_pce_without_modulator"] = baseline
+
+        if treated is None:
+            reasons.append("missing_treated_pce")
+        elif not self.guardrail.validate_pce(treated):
+            reasons.append("treated_pce_out_of_bounds")
+        else:
+            normalized["jv_reverse_scan_pce"] = treated
+
+        if delta is None:
+            if baseline is not None and treated is not None:
+                normalized["delta_pce"] = round(treated - baseline, 6)
+            else:
+                reasons.append("missing_delta_pce")
+            return
+
+        normalized["delta_pce"] = delta
+        if baseline is not None and treated is not None:
+            expected = treated - baseline
+            if abs(delta - expected) > self.delta_tolerance:
+                reasons.append("delta_pce_mismatch")
+
+
+def _clean_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, float) and math.isnan(value):
+        return ""
+    return str(value).strip()
+
+
+def _to_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if math.isnan(parsed):
+        return None
+    return parsed
+
+
+def _extract_year(record: dict[str, Any]) -> int | None:
+    for key in ("year", "publication_year", "publication_date"):
+        value = _clean_text(record.get(key))
+        if not value:
+            continue
+        match = re.search(r"(19|20)\d{2}", value)
+        if match:
+            return int(match.group(0))
+    return None
+
+
+def _normalize_title(title: str) -> str:
+    text = title.lower()
+    text = re.sub(r"<[^>]+>", " ", text)
+    text = re.sub(r"[^a-z0-9]+", " ", text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _titles_match(left: str, right: str) -> bool:
+    left_norm = _normalize_title(left)
+    right_norm = _normalize_title(right)
+    if not left_norm or not right_norm:
+        return False
+    if left_norm == right_norm:
+        return True
+    return SequenceMatcher(None, left_norm, right_norm).ratio() >= 0.92
+
+
+def _smiles_match(left: str, right: str) -> bool:
+    return left.strip() == right.strip()
+
+
+class CrossrefReferenceVerifier:
+    """Simple Crossref resolver used by production code when network is allowed."""
+
+    def __init__(self, timeout: int = 20) -> None:
+        self.timeout = timeout
+
+    def __call__(self, doi: str) -> ReferenceEvidence | None:
+        import requests
+
+        doi = doi.strip()
+        if not doi:
+            return None
+        url = f"https://api.crossref.org/works/{doi}"
+        response = requests.get(url, timeout=self.timeout)
+        if response.status_code != 200:
+            return None
+        message = response.json().get("message", {})
+        titles = message.get("title") or []
+        container = message.get("container-title") or []
+        year = _crossref_year(message)
+        return ReferenceEvidence(
+            doi=message.get("DOI", doi),
+            title=titles[0] if titles else "",
+            year=year,
+            journal=container[0] if container else None,
+            source="crossref",
+            url=message.get("URL") or f"https://doi.org/{doi}",
+        )
+
+
+class PubChemMoleculeVerifier:
+    """Simple PubChem resolver for CID-backed molecule evidence."""
+
+    def __init__(self, timeout: int = 20) -> None:
+        self.timeout = timeout
+
+    def __call__(self, record: dict[str, Any]) -> MoleculeEvidence | None:
+        import requests
+
+        cid = _clean_text(record.get("pubchem_id"))
+        if not cid:
+            return None
+        url = (
+            "https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/cid/"
+            f"{cid}/property/CanonicalSMILES/JSON"
+        )
+        response = requests.get(url, timeout=self.timeout)
+        if response.status_code != 200:
+            return None
+        props = response.json().get("PropertyTable", {}).get("Properties", [])
+        if not props:
+            return None
+        smiles = props[0].get("CanonicalSMILES")
+        if not smiles:
+            return None
+        return MoleculeEvidence(
+            smiles=smiles,
+            pubchem_id=cid,
+            cas_number=_clean_text(record.get("cas_number")) or None,
+            source="pubchem",
+            url=f"https://pubchem.ncbi.nlm.nih.gov/compound/{cid}",
+        )
+
+
+def _crossref_year(message: dict[str, Any]) -> int | None:
+    for key in ("published-print", "published-online", "issued"):
+        parts = message.get(key, {}).get("date-parts", [])
+        if parts and parts[0]:
+            return int(parts[0][0])
+    return None

--- a/tests/test_real_data_authenticity.py
+++ b/tests/test_real_data_authenticity.py
@@ -1,0 +1,132 @@
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1] / "hybrid_agent_exploration"
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+
+def _valid_record() -> dict:
+    return {
+        "record_id": "row-001",
+        "doi": "10.1021/acs.jpclett.6c00119",
+        "title": "Machine Learning Accelerated Design of Self-Assembled Monolayers for High-Performance Perovskite Solar Cells",
+        "year": 2026,
+        "journal": "Journal of Physical Chemistry Letters",
+        "smiles": "CCO",
+        "pubchem_id": "702",
+        "cas_number": "64-17-5",
+        "jv_reverse_scan_pce_without_modulator": 18.2,
+        "jv_reverse_scan_pce": 20.1,
+        "delta_pce": 1.9,
+    }
+
+
+def test_verified_record_requires_reference_and_molecule_evidence():
+    from harness.authenticity import MoleculeEvidence, RealDataAuthenticator, ReferenceEvidence
+
+    authenticator = RealDataAuthenticator(
+        reference_verifier=lambda doi: ReferenceEvidence(
+            doi=doi,
+            title="Machine Learning Accelerated Design of Self-Assembled Monolayers for High-Performance Perovskite Solar Cells",
+            year=2026,
+            journal="Journal of Physical Chemistry Letters",
+            source="fixture-crossref",
+            url="https://doi.org/10.1021/acs.jpclett.6c00119",
+        ),
+        molecule_verifier=lambda record: MoleculeEvidence(
+            smiles=record["smiles"],
+            pubchem_id="702",
+            cas_number="64-17-5",
+            source="fixture-pubchem",
+            url="https://pubchem.ncbi.nlm.nih.gov/compound/702",
+        ),
+    )
+
+    result = authenticator.verify_record(_valid_record())
+
+    assert result.status == "verified"
+    assert result.reasons == []
+    assert result.normalized["delta_pce"] == 1.9
+    assert {source["source"] for source in result.sources} == {"fixture-crossref", "fixture-pubchem"}
+
+
+def test_title_conflict_quarantines_reference_even_with_valid_doi():
+    from harness.authenticity import RealDataAuthenticator, ReferenceEvidence
+
+    authenticator = RealDataAuthenticator(
+        reference_verifier=lambda doi: ReferenceEvidence(
+            doi=doi,
+            title="A different paper title",
+            year=2026,
+            journal="Journal of Physical Chemistry Letters",
+            source="fixture-crossref",
+        ),
+        molecule_verifier=lambda record: None,
+    )
+    record = _valid_record()
+
+    result = authenticator.verify_record(record)
+
+    assert result.status == "quarantine"
+    assert "reference_title_mismatch" in result.reasons
+
+
+def test_invalid_smiles_physical_bounds_and_delta_mismatch_are_quarantined():
+    from harness.authenticity import MoleculeEvidence, RealDataAuthenticator, ReferenceEvidence
+
+    authenticator = RealDataAuthenticator(
+        reference_verifier=lambda doi: ReferenceEvidence(
+            doi=doi,
+            title=_valid_record()["title"],
+            year=2026,
+            source="fixture-crossref",
+        ),
+        molecule_verifier=lambda record: MoleculeEvidence(
+            smiles=record["smiles"],
+            pubchem_id=record.get("pubchem_id"),
+            cas_number=record.get("cas_number"),
+            source="fixture-pubchem",
+        ),
+    )
+    record = _valid_record()
+    record.update({
+        "smiles": "not a smiles !!!",
+        "jv_reverse_scan_pce_without_modulator": 18.2,
+        "jv_reverse_scan_pce": 48.0,
+        "delta_pce": 12.0,
+    })
+
+    result = authenticator.verify_record(record)
+
+    assert result.status == "quarantine"
+    assert "invalid_smiles" in result.reasons
+    assert "treated_pce_out_of_bounds" in result.reasons
+    assert "delta_pce_mismatch" in result.reasons
+
+
+def test_split_records_keeps_verified_training_rows_separate_from_quarantine():
+    from harness.authenticity import MoleculeEvidence, RealDataAuthenticator, ReferenceEvidence
+
+    authenticator = RealDataAuthenticator(
+        reference_verifier=lambda doi: ReferenceEvidence(
+            doi=doi,
+            title=_valid_record()["title"],
+            year=2026,
+            source="fixture-crossref",
+        ) if doi else None,
+        molecule_verifier=lambda record: MoleculeEvidence(
+            smiles=record["smiles"],
+            pubchem_id=record.get("pubchem_id"),
+            cas_number=record.get("cas_number"),
+            source="fixture-pubchem",
+        ),
+    )
+    missing_doi = _valid_record() | {"record_id": "row-002", "doi": ""}
+
+    split = authenticator.split_records([_valid_record(), missing_doi])
+
+    assert [row["record_id"] for row in split.verified] == ["row-001"]
+    assert [row["record_id"] for row in split.quarantine] == ["row-002"]
+    assert split.quarantine[0]["verification_status"] == "quarantine"
+    assert "missing_doi" in split.quarantine[0]["quarantine_reason"]


### PR DESCRIPTION
## Summary
- Add a strict `RealDataAuthenticator` for literature DOI/title/year evidence, molecule identity evidence, SMILES validity, PCE bounds, and `Delta_PCE` consistency.
- Add deterministic injected verifier interfaces plus Crossref/PubChem resolver implementations for production use without making network calls mandatory in tests.
- Keep verified training rows and quarantined rows explicitly separated with provenance sources and quarantine reasons.

## Tests
- `python -m pytest -q tests/test_real_data_authenticity.py`
- `python -m py_compile hybrid_agent_exploration/src/harness/authenticity.py`

## TDD Evidence
- RED: `eb08b68 test: add real data authenticity gates`
- GREEN: `0ce7c52 feat: add strict real data authenticity checker`