### PR TITLE
feat: rank verified candidate discoveries

### DIFF
--- a/hybrid_agent_exploration/src/screening/verified_candidate_discovery.py
+++ b/hybrid_agent_exploration/src/screening/verified_candidate_discovery.py
@@ -1,0 +1,243 @@
+"""Verified-only candidate discovery outputs.
+
+Candidate discovery must not silently mix quarantined or unverifiable rows into
+screening results. This module enforces `verification_status == "verified"`
+before ranking and writes a small, Git-trackable discovery bundle.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+import numpy as np
+import pandas as pd
+
+
+FeatureFn = Callable[[pd.Series], Any]
+UncertaintyFn = Callable[[Any, np.ndarray], Any]
+
+
+class UnverifiedCandidatePoolError(ValueError):
+    """Raised when a candidate pool contains non-verified rows."""
+
+
+@dataclass(frozen=True)
+class CandidateDiscoveryArtifacts:
+    """Paths and counts emitted by a verified candidate discovery run."""
+
+    output_dir: Path
+    ranked_candidates_csv: Path
+    discovery_manifest_json: Path
+    audit_report_md: Path
+    input_count: int
+    ranked_count: int
+
+
+class VerifiedCandidateDiscovery:
+    """Rank candidates only after strict verification status checks pass."""
+
+    def __init__(self, *, output_dir: str | Path) -> None:
+        self.output_dir = Path(output_dir)
+
+    def discover(
+        self,
+        candidate_pool: pd.DataFrame | str | Path,
+        *,
+        model: Any,
+        feature_fn: FeatureFn,
+        top_k: int = 100,
+        dataset_id: str,
+        uncertainty_fn: UncertaintyFn | None = None,
+    ) -> CandidateDiscoveryArtifacts:
+        """Rank a verified candidate pool and write discovery artifacts."""
+
+        df = _load_candidate_pool(candidate_pool)
+        _require_verified(df)
+        ranked = _rank_candidates(
+            df,
+            model=model,
+            feature_fn=feature_fn,
+            top_k=top_k,
+            uncertainty_fn=uncertainty_fn,
+        )
+
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        artifacts = CandidateDiscoveryArtifacts(
+            output_dir=self.output_dir,
+            ranked_candidates_csv=self.output_dir / "ranked_candidates.csv",
+            discovery_manifest_json=self.output_dir / "candidate_discovery_manifest.json",
+            audit_report_md=self.output_dir / "candidate_discovery_audit.md",
+            input_count=len(df),
+            ranked_count=len(ranked),
+        )
+        ranked.to_csv(artifacts.ranked_candidates_csv, index=False)
+        _write_json(_manifest(dataset_id, artifacts, df, ranked, top_k, model), artifacts.discovery_manifest_json)
+        artifacts.audit_report_md.write_text(
+            _audit_report(dataset_id, artifacts, ranked),
+            encoding="utf-8",
+        )
+        return artifacts
+
+
+def _load_candidate_pool(candidate_pool: pd.DataFrame | str | Path) -> pd.DataFrame:
+    if isinstance(candidate_pool, pd.DataFrame):
+        return candidate_pool.copy()
+    path = Path(candidate_pool)
+    if not path.exists():
+        raise FileNotFoundError(f"Candidate pool not found: {path}")
+    if path.suffix.lower() == ".csv":
+        return pd.read_csv(path, low_memory=False)
+    if path.suffix.lower() in {".xlsx", ".xls"}:
+        return pd.read_excel(path)
+    raise ValueError(f"Unsupported candidate pool format: {path.suffix}")
+
+
+def _require_verified(df: pd.DataFrame) -> None:
+    if "verification_status" not in df.columns:
+        raise UnverifiedCandidatePoolError(
+            "Candidate discovery requires verification_status=verified for every row; "
+            "missing column verification_status."
+        )
+    status = df["verification_status"].fillna("").astype(str)
+    bad = df[status != "verified"]
+    if bad.empty:
+        return
+    identifiers = _row_identifiers(bad)
+    raise UnverifiedCandidatePoolError(
+        "Candidate discovery requires verification_status=verified for every row; "
+        f"blocked rows: {', '.join(identifiers)}"
+    )
+
+
+def _row_identifiers(df: pd.DataFrame, limit: int = 10) -> list[str]:
+    if "record_id" in df.columns:
+        values = df["record_id"].fillna("").astype(str)
+        ids = [value for value in values.tolist() if value]
+    else:
+        ids = [f"index:{idx}" for idx in df.index.tolist()]
+    return ids[:limit]
+
+
+def _rank_candidates(
+    df: pd.DataFrame,
+    *,
+    model: Any,
+    feature_fn: FeatureFn,
+    top_k: int,
+    uncertainty_fn: UncertaintyFn | None,
+) -> pd.DataFrame:
+    if "smiles" not in df.columns:
+        raise ValueError("Candidate pool must contain a smiles column.")
+    if top_k < 1:
+        raise ValueError("top_k must be >= 1.")
+
+    features = feature_fn(df["smiles"])
+    X = _as_feature_array(features)
+    predictions = np.asarray(model.predict(X), dtype=float)
+    if len(predictions) != len(df):
+        raise ValueError("Model prediction length does not match candidate pool length.")
+
+    ranked = df.copy()
+    ranked["predicted_delta_pce"] = predictions
+    if uncertainty_fn is not None:
+        ranked["uncertainty"] = np.asarray(uncertainty_fn(model, X), dtype=float)
+    ranked = ranked.sort_values("predicted_delta_pce", ascending=False).reset_index(drop=True)
+    ranked["rank"] = np.arange(1, len(ranked) + 1)
+    return ranked.head(top_k).reset_index(drop=True)
+
+
+def _as_feature_array(features: Any) -> np.ndarray:
+    if isinstance(features, pd.DataFrame):
+        return features.fillna(0).to_numpy()
+    if isinstance(features, pd.Series):
+        return features.fillna(0).to_numpy().reshape(-1, 1)
+    array = np.asarray(features)
+    if array.ndim == 1:
+        array = array.reshape(-1, 1)
+    return array
+
+
+def _manifest(
+    dataset_id: str,
+    artifacts: CandidateDiscoveryArtifacts,
+    source_df: pd.DataFrame,
+    ranked_df: pd.DataFrame,
+    top_k: int,
+    model: Any,
+) -> dict[str, Any]:
+    return {
+        "dataset_id": dataset_id,
+        "generated_at": _now_iso(),
+        "requires_verified_candidates": True,
+        "input_rows": artifacts.input_count,
+        "ranked_rows": artifacts.ranked_count,
+        "top_k": top_k,
+        "model_class": model.__class__.__name__,
+        "input_columns": list(source_df.columns),
+        "ranked_columns": list(ranked_df.columns),
+        "outputs": {
+            "ranked_candidates_csv": artifacts.ranked_candidates_csv.name,
+            "discovery_manifest_json": artifacts.discovery_manifest_json.name,
+            "audit_report_md": artifacts.audit_report_md.name,
+        },
+    }
+
+
+def _audit_report(
+    dataset_id: str,
+    artifacts: CandidateDiscoveryArtifacts,
+    ranked_df: pd.DataFrame,
+) -> str:
+    lines = [
+        f"# Verified Candidate Discovery Audit: {dataset_id}",
+        "",
+        "- Gate: verified-only candidate pool (`verification_status=verified`).",
+        f"- Input candidates: {artifacts.input_count}",
+        f"- Ranked candidates emitted: {artifacts.ranked_count}",
+        "",
+        "## Top Candidates",
+        "",
+    ]
+    if ranked_df.empty:
+        lines.append("- None")
+    else:
+        for _, row in ranked_df.head(10).iterrows():
+            record_id = _text(row.get("record_id")) or "unknown"
+            smiles = _text(row.get("smiles")) or "unknown"
+            score = row.get("predicted_delta_pce")
+            lines.append(f"- {record_id}: `{smiles}` predicted_delta_pce={score}")
+    lines.extend(
+        [
+            "",
+            "## Outputs",
+            "",
+            f"- `{artifacts.ranked_candidates_csv.name}`",
+            f"- `{artifacts.discovery_manifest_json.name}`",
+            f"- `{artifacts.audit_report_md.name}`",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _write_json(payload: dict[str, Any], path: Path) -> None:
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _text(value: Any) -> str:
+    if value is None:
+        return ""
+    try:
+        if pd.isna(value):
+            return ""
+    except (TypeError, ValueError):
+        pass
+    return str(value).strip()
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()

--- a/tests/test_verified_candidate_discovery.py
+++ b/tests/test_verified_candidate_discovery.py
@@ -1,0 +1,100 @@
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1] / "hybrid_agent_exploration"
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+
+class LengthModel:
+    def predict(self, features):
+        return features[:, 0] * 0.25
+
+
+def _feature_fn(smiles_series):
+    return pd.DataFrame({"smiles_length": smiles_series.astype(str).str.len()})
+
+
+def _verified_pool() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "record_id": "row-001",
+                "smiles": "CC",
+                "doi": "10.1021/acs.jpclett.6c00119",
+                "verification_status": "verified",
+                "verification_sources": json.dumps([
+                    {"kind": "reference", "source": "fixture-crossref", "doi": "10.1021/acs.jpclett.6c00119"}
+                ]),
+            },
+            {
+                "record_id": "row-002",
+                "smiles": "CCCC",
+                "doi": "10.1021/acs.jpclett.6c00120",
+                "verification_status": "verified",
+                "verification_sources": json.dumps([
+                    {"kind": "reference", "source": "fixture-crossref", "doi": "10.1021/acs.jpclett.6c00120"}
+                ]),
+            },
+        ]
+    )
+
+
+def test_discovery_ranks_verified_pool_and_writes_outputs(tmp_path):
+    from screening.verified_candidate_discovery import VerifiedCandidateDiscovery
+
+    artifacts = VerifiedCandidateDiscovery(output_dir=tmp_path).discover(
+        _verified_pool(),
+        model=LengthModel(),
+        feature_fn=_feature_fn,
+        top_k=1,
+        dataset_id="verified-candidate-fixture",
+    )
+
+    assert artifacts.ranked_count == 1
+    assert artifacts.ranked_candidates_csv.exists()
+    assert artifacts.discovery_manifest_json.exists()
+    assert artifacts.audit_report_md.exists()
+
+    ranked = pd.read_csv(artifacts.ranked_candidates_csv)
+    assert ranked["record_id"].tolist() == ["row-002"]
+    assert ranked["rank"].tolist() == [1]
+    assert ranked["verification_status"].tolist() == ["verified"]
+    assert ranked["predicted_delta_pce"].tolist() == [1.0]
+    assert "fixture-crossref" in ranked.loc[0, "verification_sources"]
+
+    manifest = json.loads(artifacts.discovery_manifest_json.read_text(encoding="utf-8"))
+    assert manifest["dataset_id"] == "verified-candidate-fixture"
+    assert manifest["input_rows"] == 2
+    assert manifest["ranked_rows"] == 1
+    assert manifest["requires_verified_candidates"] is True
+    assert manifest["outputs"]["ranked_candidates_csv"] == "ranked_candidates.csv"
+
+    report = artifacts.audit_report_md.read_text(encoding="utf-8")
+    assert "verified-only" in report
+    assert "row-002" in report
+
+
+def test_discovery_refuses_quarantined_or_unverified_rows(tmp_path):
+    from screening.verified_candidate_discovery import (
+        UnverifiedCandidatePoolError,
+        VerifiedCandidateDiscovery,
+    )
+
+    pool = _verified_pool()
+    pool.loc[1, "verification_status"] = "quarantine"
+
+    with pytest.raises(UnverifiedCandidatePoolError) as exc:
+        VerifiedCandidateDiscovery(output_dir=tmp_path).discover(
+            pool,
+            model=LengthModel(),
+            feature_fn=_feature_fn,
+            dataset_id="bad-pool",
+        )
+
+    assert "row-002" in str(exc.value)
+    assert "verification_status=verified" in str(exc.value)


### PR DESCRIPTION
## Summary
- Add a verified-only candidate discovery runner that refuses any candidate pool row without `verification_status=verified`.
- Rank candidates by predicted `Delta_PCE` while preserving provenance columns such as DOI and verification sources.
- Emit `ranked_candidates.csv`, `candidate_discovery_manifest.json`, and `candidate_discovery_audit.md` as small, Git-trackable discovery artifacts.

## Tests
- `python -m pytest -q tests/test_real_data_authenticity.py tests/test_verified_dataset_builder.py tests/test_verified_candidate_discovery.py tests/test_top_journal_reporting.py`
- `python -m py_compile hybrid_agent_exploration/src/screening/verified_candidate_discovery.py`

## TDD Evidence
- RED: `bbc1325 test: add verified candidate discovery expectations`
- GREEN: `3a6b183 feat: rank verified candidate discoveries`