### PR TITLE
feat: add verified discovery CLI

### DIFF
--- a/hybrid_agent_exploration/src/run_verified_discovery.py
+++ b/hybrid_agent_exploration/src/run_verified_discovery.py
@@ -1,0 +1,193 @@
+"""CLI for strict verified PSC additive discovery runs."""
+
+from __future__ import annotations
+
+import argparse
+import math
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from harness.authenticity import (
+    CachedMoleculeVerifier,
+    CachedReferenceVerifier,
+    CrossrefReferenceVerifier,
+    MoleculeEvidence,
+    PubChemMoleculeVerifier,
+    RealDataAuthenticator,
+    ReferenceEvidence,
+)
+from screening.verified_discovery_workflow import VerifiedDiscoveryWorkflow
+
+
+EVIDENCE_MODES = ("external-cached", "source-columns")
+
+
+class SourceColumnReferenceVerifier:
+    """Reference verifier backed by DOI/title/year/journal columns in the input table."""
+
+    def __init__(self, df: pd.DataFrame) -> None:
+        self.references: dict[str, ReferenceEvidence] = {}
+        if "doi" not in df.columns:
+            return
+        for record in df.to_dict(orient="records"):
+            doi = _normalize_doi(record.get("doi"))
+            if not doi or doi in self.references:
+                continue
+            title = _clean_text(record.get("title"))
+            if not title:
+                continue
+            self.references[doi] = ReferenceEvidence(
+                doi=doi,
+                title=title,
+                year=_extract_year(record),
+                journal=_clean_text(record.get("journal")) or None,
+                source="source-columns",
+                url=f"https://doi.org/{doi}",
+            )
+
+    def __call__(self, doi: str) -> ReferenceEvidence | None:
+        return self.references.get(_normalize_doi(doi))
+
+
+class SourceColumnMoleculeVerifier:
+    """Molecule verifier backed by SMILES/PubChem/CAS columns in the input table."""
+
+    def __call__(self, record: dict[str, Any]) -> MoleculeEvidence | None:
+        smiles = _clean_text(record.get("smiles"))
+        if not smiles:
+            return None
+        pubchem_id = _normalize_pubchem_id(record.get("pubchem_id")) or None
+        return MoleculeEvidence(
+            smiles=smiles,
+            pubchem_id=pubchem_id,
+            cas_number=_clean_text(record.get("cas_number")) or None,
+            source="source-columns",
+            url=f"https://pubchem.ncbi.nlm.nih.gov/compound/{pubchem_id}" if pubchem_id else None,
+        )
+
+
+def build_authenticator(
+    evidence_mode: str,
+    df: pd.DataFrame,
+    cache_dir: str | Path,
+) -> RealDataAuthenticator:
+    """Build the strict authenticator requested by the CLI."""
+
+    if evidence_mode == "external-cached":
+        cache_dir = Path(cache_dir)
+        return RealDataAuthenticator(
+            reference_verifier=CachedReferenceVerifier(
+                CrossrefReferenceVerifier(),
+                cache_dir / "reference_cache.json",
+            ),
+            molecule_verifier=CachedMoleculeVerifier(
+                PubChemMoleculeVerifier(),
+                cache_dir / "molecule_cache.json",
+            ),
+        )
+    if evidence_mode == "source-columns":
+        return RealDataAuthenticator(
+            reference_verifier=SourceColumnReferenceVerifier(df),
+            molecule_verifier=SourceColumnMoleculeVerifier(),
+        )
+    raise ValueError(f"Unknown evidence mode: {evidence_mode}")
+
+
+def load_input(path: str | Path, *, max_rows: int | None = None) -> pd.DataFrame:
+    """Load a CSV/XLSX input table for verified discovery."""
+
+    input_path = Path(path)
+    if not input_path.exists():
+        raise FileNotFoundError(f"Input table not found: {input_path}")
+    if input_path.suffix.lower() == ".csv":
+        return pd.read_csv(input_path, nrows=max_rows, low_memory=False)
+    if input_path.suffix.lower() in {".xlsx", ".xls"}:
+        return pd.read_excel(input_path, nrows=max_rows)
+    raise ValueError(f"Unsupported input table format: {input_path.suffix}")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, help="CSV/XLSX table with PSC additive rows.")
+    parser.add_argument("--output-dir", required=True, help="Directory for all workflow artifacts.")
+    parser.add_argument("--dataset-id", required=True, help="Stable dataset/run identifier.")
+    parser.add_argument(
+        "--evidence-mode",
+        choices=EVIDENCE_MODES,
+        default="external-cached",
+        help="Evidence source. external-cached uses Crossref/PubChem with JSON caches; source-columns is a fast local smoke mode.",
+    )
+    parser.add_argument("--cache-dir", help="Evidence cache directory; defaults to <output-dir>/evidence_cache.")
+    parser.add_argument("--top-k", type=int, default=100, help="Number of ranked candidates to emit.")
+    parser.add_argument("--min-verified-rows", type=int, default=10, help="Minimum strict verified training rows.")
+    parser.add_argument("--max-rows", type=int, help="Optional input row cap for smoke runs.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    output_dir = Path(args.output_dir)
+    df = load_input(args.input, max_rows=args.max_rows)
+    cache_dir = Path(args.cache_dir) if args.cache_dir else output_dir / "evidence_cache"
+    authenticator = build_authenticator(args.evidence_mode, df, cache_dir)
+    artifacts = VerifiedDiscoveryWorkflow(
+        output_dir=output_dir,
+        authenticator=authenticator,
+    ).run_from_dataframe(
+        df,
+        dataset_id=args.dataset_id,
+        top_k=args.top_k,
+        min_verified_rows=args.min_verified_rows,
+    )
+    print(f"[verified-discovery] workflow_manifest={artifacts.workflow_manifest_json}")
+    print(f"[verified-discovery] verified_rows={artifacts.verified_rows}")
+    print(f"[verified-discovery] quarantine_rows={artifacts.quarantine_rows}")
+    print(f"[verified-discovery] ranked_candidates={artifacts.ranked_candidates}")
+    return 0
+
+
+def _clean_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, float) and math.isnan(value):
+        return ""
+    return str(value).strip()
+
+
+def _normalize_doi(value: Any) -> str:
+    return _clean_text(value).lower()
+
+
+def _normalize_pubchem_id(value: Any) -> str:
+    text = _clean_text(value)
+    if not text:
+        return ""
+    try:
+        parsed = float(text)
+    except ValueError:
+        return text
+    if math.isnan(parsed):
+        return ""
+    if parsed.is_integer():
+        return str(int(parsed))
+    return text
+
+
+def _extract_year(record: dict[str, Any]) -> int | None:
+    for key in ("year", "publication_year", "publication_date"):
+        text = _clean_text(record.get(key))
+        if not text:
+            continue
+        try:
+            return int(float(text))
+        except ValueError:
+            for token in text.replace("-", " ").replace("/", " ").split():
+                if len(token) == 4 and token.isdigit() and token.startswith(("19", "20")):
+                    return int(token)
+    return None
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_run_verified_discovery_cli.py
+++ b/tests/test_run_verified_discovery_cli.py
@@ -1,0 +1,83 @@
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1] / "hybrid_agent_exploration"
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+
+def _record(record_id: str, doi: str, smiles: str, delta: float, *, title: str = "Verified source title") -> dict:
+    return {
+        "record_id": record_id,
+        "doi": doi,
+        "title": title,
+        "publication_date": 2026,
+        "journal": "Journal of Physical Chemistry Letters",
+        "smiles": smiles,
+        "pubchem_id": str(900 + int(record_id.split("-")[-1])),
+        "cas_number": f"64-17-{record_id[-1]}",
+        "jv_reverse_scan_pce_without_modulator": 18.0,
+        "jv_reverse_scan_pce": 18.0 + delta,
+    }
+
+
+def test_cli_runs_source_column_verified_discovery_smoke(tmp_path):
+    from run_verified_discovery import main
+
+    input_csv = tmp_path / "raw.csv"
+    output_dir = tmp_path / "out"
+    pd.DataFrame(
+        [
+            _record("row-001", "10.1021/acs.jpclett.6c00119", "C", 0.25),
+            _record("row-002", "10.1021/acs.jpclett.6c00120", "CC", 0.50),
+            _record("row-003", "", "CCC", 0.75, title="Missing DOI row"),
+        ]
+    ).to_csv(input_csv, index=False)
+
+    exit_code = main(
+        [
+            "--input",
+            str(input_csv),
+            "--output-dir",
+            str(output_dir),
+            "--dataset-id",
+            "cli-source-fixture",
+            "--evidence-mode",
+            "source-columns",
+            "--min-verified-rows",
+            "2",
+            "--top-k",
+            "1",
+        ]
+    )
+
+    assert exit_code == 0
+    workflow_manifest = output_dir / "workflow_manifest.json"
+    assert workflow_manifest.exists()
+    manifest = json.loads(workflow_manifest.read_text(encoding="utf-8"))
+    assert manifest["dataset_id"] == "cli-source-fixture"
+    assert manifest["verified_rows"] == 2
+    assert manifest["quarantine_rows"] == 1
+    assert manifest["ranked_candidates"] == 1
+
+    verified = pd.read_csv(output_dir / "dataset" / "verified_train.csv")
+    quarantine = pd.read_csv(output_dir / "dataset" / "quarantine.csv")
+    ranked = pd.read_csv(output_dir / "discovery" / "ranked_candidates.csv")
+
+    assert verified["record_id"].tolist() == ["row-001", "row-002"]
+    assert quarantine["record_id"].tolist() == ["row-003"]
+    assert ranked["record_id"].tolist() == ["row-002"]
+    assert "source-columns" in verified.loc[0, "verification_sources"]
+
+
+def test_cli_external_cached_mode_initializes_cache_paths(tmp_path):
+    from run_verified_discovery import build_authenticator
+
+    cache_dir = tmp_path / "cache"
+    authenticator = build_authenticator("external-cached", pd.DataFrame(), cache_dir)
+
+    assert authenticator.reference_verifier.cache_path == cache_dir / "reference_cache.json"
+    assert authenticator.molecule_verifier.cache_path == cache_dir / "molecule_cache.json"


### PR DESCRIPTION
## Summary
- Add `run_verified_discovery.py` as a callable entry point for strict PSC additive discovery runs from CSV/XLSX inputs.
- Support `external-cached` mode using Crossref/PubChem with JSON evidence caches and `source-columns` mode for fast local smoke runs.
- Wire the CLI into the verified discovery workflow so one command emits dataset, quarantine, DOI manifest, provenance, model, ranking, audit, and workflow manifest artifacts.

## Tests
- `python -m pytest -q tests/test_run_verified_discovery_cli.py tests/test_evidence_cache_verifiers.py tests/test_real_data_authenticity.py tests/test_verified_dataset_builder.py tests/test_verified_candidate_discovery.py tests/test_verified_discovery_workflow.py tests/test_top_journal_reporting.py`
- `python -m py_compile hybrid_agent_exploration/src/run_verified_discovery.py`

## TDD Evidence
- RED: `2c5cc7d test: add verified discovery CLI expectations`
- GREEN: `152c60e feat: add verified discovery CLI`