### PR TITLE
feat: harden verified discovery runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,8 @@ dashboard.html
 fingerprints/
 
 # ===== Exploration data caches =====
+hybrid_agent_exploration/.cache/
+**/evidence_cache/
 hybrid_agent_exploration/data_cache.*
 hybrid_agent_exploration/explorations/data_source_exploration/.cache/
 hybrid_agent_exploration/explorations/data_source_exploration/cleaned_data.csv
@@ -93,6 +95,8 @@ hybrid_agent_exploration/explorations/three_way_comparison_summary.csv
 hybrid_agent_exploration/explorations/three_way_comparison_agentic_summary.csv
 hybrid_agent_exploration/explorations/deployment_screening_exploration/ranking_*.csv
 hybrid_agent_exploration/explorations/evaluation_strategy_exploration/evaluation_comparison_summary.csv
+hybrid_agent_exploration/results/verified_discovery_runs/
+hybrid_agent_exploration/results/verified_discovery_smoke*/
 
 # ===== Article preview images (duplicates of figures/) =====
 hybrid_agent_exploration/article/preview-*.png

--- a/hybrid_agent_exploration/src/harness/authenticity.py
+++ b/hybrid_agent_exploration/src/harness/authenticity.py
@@ -410,7 +410,10 @@ class CrossrefReferenceVerifier:
         if not doi:
             return None
         url = f"https://api.crossref.org/works/{doi}"
-        response = requests.get(url, timeout=self.timeout)
+        try:
+            response = requests.get(url, timeout=self.timeout)
+        except requests.RequestException:
+            return None
         if response.status_code != 200:
             return None
         message = response.json().get("message", {})
@@ -441,7 +444,10 @@ class PubChemMoleculeVerifier:
             "https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/cid/"
             f"{cid}/property/CanonicalSMILES/JSON"
         )
-        response = requests.get(url, timeout=self.timeout)
+        try:
+            response = requests.get(url, timeout=self.timeout)
+        except requests.RequestException:
+            return None
         if response.status_code != 200:
             return None
         props = response.json().get("PropertyTable", {}).get("Properties", [])

--- a/hybrid_agent_exploration/src/run_verified_discovery.py
+++ b/hybrid_agent_exploration/src/run_verified_discovery.py
@@ -22,6 +22,7 @@ from screening.verified_discovery_workflow import VerifiedDiscoveryWorkflow
 
 
 EVIDENCE_MODES = ("external-cached", "source-columns")
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
 class SourceColumnReferenceVerifier:
@@ -95,6 +96,13 @@ def build_authenticator(
     raise ValueError(f"Unknown evidence mode: {evidence_mode}")
 
 
+def default_cache_dir(dataset_id: str) -> Path:
+    """Return the ignored default evidence-cache directory for a run."""
+
+    safe_dataset_id = "".join(ch if ch.isalnum() or ch in ("-", "_", ".") else "_" for ch in dataset_id)
+    return PROJECT_ROOT / ".cache" / "verified_discovery" / safe_dataset_id / "evidence_cache"
+
+
 def load_input(path: str | Path, *, max_rows: int | None = None) -> pd.DataFrame:
     """Load a CSV/XLSX input table for verified discovery."""
 
@@ -119,7 +127,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default="external-cached",
         help="Evidence source. external-cached uses Crossref/PubChem with JSON caches; source-columns is a fast local smoke mode.",
     )
-    parser.add_argument("--cache-dir", help="Evidence cache directory; defaults to <output-dir>/evidence_cache.")
+    parser.add_argument(
+        "--cache-dir",
+        help="Evidence cache directory; defaults to hybrid_agent_exploration/.cache/verified_discovery/<dataset-id>/evidence_cache.",
+    )
     parser.add_argument("--top-k", type=int, default=100, help="Number of ranked candidates to emit.")
     parser.add_argument("--min-verified-rows", type=int, default=10, help="Minimum strict verified training rows.")
     parser.add_argument("--max-rows", type=int, help="Optional input row cap for smoke runs.")
@@ -130,8 +141,18 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     output_dir = Path(args.output_dir)
     df = load_input(args.input, max_rows=args.max_rows)
-    cache_dir = Path(args.cache_dir) if args.cache_dir else output_dir / "evidence_cache"
+    cache_dir = Path(args.cache_dir) if args.cache_dir else default_cache_dir(args.dataset_id)
     authenticator = build_authenticator(args.evidence_mode, df, cache_dir)
+    run_metadata = {
+        "evidence_mode": args.evidence_mode,
+        "verification_level": "external_cached" if args.evidence_mode == "external-cached" else "source_columns_only",
+        "publication_grade": args.evidence_mode == "external-cached",
+        "source_columns_is_smoke_only": args.evidence_mode == "source-columns",
+        "input_path": str(Path(args.input)),
+        "max_rows": args.max_rows,
+    }
+    if args.evidence_mode == "external-cached":
+        run_metadata["cache_dir"] = str(cache_dir)
     artifacts = VerifiedDiscoveryWorkflow(
         output_dir=output_dir,
         authenticator=authenticator,
@@ -140,6 +161,7 @@ def main(argv: list[str] | None = None) -> int:
         dataset_id=args.dataset_id,
         top_k=args.top_k,
         min_verified_rows=args.min_verified_rows,
+        run_metadata=run_metadata,
     )
     print(f"[verified-discovery] workflow_manifest={artifacts.workflow_manifest_json}")
     print(f"[verified-discovery] verified_rows={artifacts.verified_rows}")

--- a/hybrid_agent_exploration/src/screening/verified_discovery_workflow.py
+++ b/hybrid_agent_exploration/src/screening/verified_discovery_workflow.py
@@ -80,6 +80,7 @@ class VerifiedDiscoveryWorkflow:
         min_verified_rows: int = 10,
         target_column: str = "delta_pce",
         smiles_column: str = "smiles",
+        run_metadata: dict[str, Any] | None = None,
     ) -> VerifiedDiscoveryWorkflowArtifacts:
         """Run the workflow from a CSV/XLSX input table."""
 
@@ -95,6 +96,7 @@ class VerifiedDiscoveryWorkflow:
             min_verified_rows=min_verified_rows,
             target_column=target_column,
             smiles_column=smiles_column,
+            run_metadata=run_metadata,
         )
 
     def run_from_dataframe(
@@ -109,6 +111,7 @@ class VerifiedDiscoveryWorkflow:
         min_verified_rows: int = 10,
         target_column: str = "delta_pce",
         smiles_column: str = "smiles",
+        run_metadata: dict[str, Any] | None = None,
     ) -> VerifiedDiscoveryWorkflowArtifacts:
         """Run the full verified discovery workflow from an in-memory table."""
 
@@ -191,6 +194,7 @@ class VerifiedDiscoveryWorkflow:
                 min_verified_rows=min_verified_rows,
                 top_k=top_k,
                 model_class=trained_model.__class__.__name__,
+                run_metadata=run_metadata,
             ),
             workflow_manifest_json,
         )
@@ -326,6 +330,7 @@ def _workflow_manifest(
     min_verified_rows: int,
     top_k: int,
     model_class: str,
+    run_metadata: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     outputs = {
         key: value.relative_to(artifacts["verified_train_csv"].parents[1]).as_posix()
@@ -335,7 +340,7 @@ def _workflow_manifest(
     outputs["workflow_manifest_json"] = workflow_manifest_json.relative_to(
         artifacts["verified_train_csv"].parents[1]
     ).as_posix()
-    return {
+    manifest = {
         "dataset_id": dataset_id,
         "generated_at": _now_iso(),
         "artifact_policy": ARTIFACT_POLICY,
@@ -349,6 +354,9 @@ def _workflow_manifest(
         "ranked_candidates": artifacts["ranked_candidates"],
         "outputs": outputs,
     }
+    if run_metadata:
+        manifest.update(run_metadata)
+    return manifest
 
 
 def _write_json(payload: dict[str, Any], path: Path) -> None:

--- a/tests/test_evidence_cache_verifiers.py
+++ b/tests/test_evidence_cache_verifiers.py
@@ -108,3 +108,27 @@ def test_cached_molecule_verifier_keys_by_normalized_pubchem_id(tmp_path):
     payload = json.loads(cache_path.read_text(encoding="utf-8"))
     assert list(payload) == ["pubchem:104810"]
     assert payload["pubchem:104810"]["smiles"] == "[Ba+2]"
+
+
+def test_external_reference_timeout_returns_none_without_abort(monkeypatch):
+    from harness import authenticity
+    from harness.authenticity import CrossrefReferenceVerifier
+
+    def fake_get(url, timeout):
+        raise authenticity.requests.Timeout("crossref timed out")
+
+    monkeypatch.setattr(authenticity.requests, "get", fake_get)
+
+    assert CrossrefReferenceVerifier(timeout=1)("10.1021/acs.jpclett.6c00119") is None
+
+
+def test_external_molecule_timeout_returns_none_without_abort(monkeypatch):
+    from harness import authenticity
+    from harness.authenticity import PubChemMoleculeVerifier
+
+    def fake_get(url, timeout):
+        raise authenticity.requests.Timeout("pubchem timed out")
+
+    monkeypatch.setattr(authenticity.requests, "get", fake_get)
+
+    assert PubChemMoleculeVerifier(timeout=1)({"pubchem_id": "104810.0"}) is None

--- a/tests/test_run_verified_discovery_cli.py
+++ b/tests/test_run_verified_discovery_cli.py
@@ -59,6 +59,13 @@ def test_cli_runs_source_column_verified_discovery_smoke(tmp_path):
     assert workflow_manifest.exists()
     manifest = json.loads(workflow_manifest.read_text(encoding="utf-8"))
     assert manifest["dataset_id"] == "cli-source-fixture"
+    assert manifest["evidence_mode"] == "source-columns"
+    assert manifest["verification_level"] == "source_columns_only"
+    assert manifest["publication_grade"] is False
+    assert manifest["source_columns_is_smoke_only"] is True
+    assert manifest["input_path"] == str(input_csv)
+    assert manifest["max_rows"] is None
+    assert "cache_dir" not in manifest
     assert manifest["verified_rows"] == 2
     assert manifest["quarantine_rows"] == 1
     assert manifest["ranked_candidates"] == 1
@@ -74,10 +81,19 @@ def test_cli_runs_source_column_verified_discovery_smoke(tmp_path):
 
 
 def test_cli_external_cached_mode_initializes_cache_paths(tmp_path):
-    from run_verified_discovery import build_authenticator
+    from run_verified_discovery import build_authenticator, default_cache_dir
 
-    cache_dir = tmp_path / "cache"
+    cache_dir = default_cache_dir("external-fixture")
     authenticator = build_authenticator("external-cached", pd.DataFrame(), cache_dir)
 
+    assert cache_dir.as_posix().endswith("hybrid_agent_exploration/.cache/verified_discovery/external-fixture/evidence_cache")
     assert authenticator.reference_verifier.cache_path == cache_dir / "reference_cache.json"
     assert authenticator.molecule_verifier.cache_path == cache_dir / "molecule_cache.json"
+
+
+def test_gitignore_excludes_verified_discovery_runtime_outputs():
+    gitignore = (Path(__file__).resolve().parents[1] / ".gitignore").read_text(encoding="utf-8")
+
+    assert "hybrid_agent_exploration/.cache/" in gitignore
+    assert "hybrid_agent_exploration/results/verified_discovery_runs/" in gitignore
+    assert "**/evidence_cache/" in gitignore

--- a/tests/test_run_verified_discovery_cli.py
+++ b/tests/test_run_verified_discovery_cli.py
@@ -96,4 +96,5 @@ def test_gitignore_excludes_verified_discovery_runtime_outputs():
 
     assert "hybrid_agent_exploration/.cache/" in gitignore
     assert "hybrid_agent_exploration/results/verified_discovery_runs/" in gitignore
+    assert "hybrid_agent_exploration/results/verified_discovery_smoke*/" in gitignore
     assert "**/evidence_cache/" in gitignore


### PR DESCRIPTION
## Summary
- Record `evidence_mode`, verification level, publication-grade status, input path, and max-row cap in `workflow_manifest.json`.
- Move default external evidence caches to ignored `hybrid_agent_exploration/.cache/verified_discovery/<dataset-id>/evidence_cache` and ignore verified discovery smoke/run output directories.
- Catch Crossref/PubChem request exceptions so one timeout does not abort an entire run.

## Tests
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_run_verified_discovery_cli.py tests/test_evidence_cache_verifiers.py tests/test_real_data_authenticity.py tests/test_verified_dataset_builder.py tests/test_verified_candidate_discovery.py tests/test_verified_discovery_workflow.py tests/test_top_journal_reporting.py`
- `python -m py_compile hybrid_agent_exploration/src/run_verified_discovery.py hybrid_agent_exploration/src/screening/verified_discovery_workflow.py hybrid_agent_exploration/src/harness/authenticity.py`

## TDD Evidence
- RED: `aff4ea8 test: add verified run safety expectations`
- GREEN: `ba37a6f feat: harden verified discovery runs`

## Real Smoke Evidence
- Agent A ran `source-columns` smoke on 500 real CSV rows: 30 verified, 470 quarantine, 17 ranked candidates, all 12 expected artifacts present.