### PR TITLE
feat: assign stable source record ids

### DIFF
--- a/hybrid_agent_exploration/src/data/verified_dataset_builder.py
+++ b/hybrid_agent_exploration/src/data/verified_dataset_builder.py
@@ -90,6 +90,7 @@ class VerifiedDatasetBuilder:
         """Verify a dataframe and write the complete artifact bundle."""
 
         self.output_dir.mkdir(parents=True, exist_ok=True)
+        df = _ensure_record_ids(df)
         records = df.to_dict(orient="records")
         split = self.authenticator.split_records(records)
 
@@ -131,6 +132,22 @@ def _load_table(path: Path) -> pd.DataFrame:
     if suffix in {".xlsx", ".xls"}:
         return pd.read_excel(path)
     raise ValueError(f"Unsupported input table format: {path.suffix}")
+
+
+def _ensure_record_ids(df: pd.DataFrame) -> pd.DataFrame:
+    output = df.copy()
+    if "record_id" not in output.columns:
+        output.insert(0, "record_id", [_source_record_id(idx) for idx in range(len(output))])
+        return output
+    record_ids = output["record_id"].map(_text)
+    missing = record_ids == ""
+    if missing.any():
+        output.loc[missing, "record_id"] = [_source_record_id(idx) for idx in output.index[missing]]
+    return output
+
+
+def _source_record_id(zero_based_index: int) -> str:
+    return f"source_row_{zero_based_index + 1:06d}"
 
 
 def _serialize_row(row: dict[str, Any]) -> dict[str, Any]:

--- a/tests/test_verified_dataset_builder.py
+++ b/tests/test_verified_dataset_builder.py
@@ -119,3 +119,25 @@ def test_builder_loads_csv_and_computes_delta_when_missing(tmp_path):
     verified = pd.read_csv(artifacts.verified_train_csv)
     assert verified["record_id"].tolist() == ["row-003"]
     assert verified.loc[0, "delta_pce"] == 2.5
+
+
+def test_builder_assigns_stable_record_ids_when_source_has_none(tmp_path):
+    from data.verified_dataset_builder import VerifiedDatasetBuilder
+
+    first = _record("row-001", "10.1021/acs.jpclett.6c00119")
+    second = _record("row-002", "", title="Missing DOI row")
+    for row in (first, second):
+        row.pop("record_id")
+
+    artifacts = VerifiedDatasetBuilder(_authenticator(), output_dir=tmp_path).build_from_dataframe(
+        pd.DataFrame([first, second]),
+        dataset_id="missing-record-id-fixture",
+    )
+
+    verified = pd.read_csv(artifacts.verified_train_csv)
+    quarantine = pd.read_csv(artifacts.quarantine_csv)
+    candidate_pool = pd.read_csv(artifacts.candidate_pool_csv)
+
+    assert verified["record_id"].tolist() == ["source_row_000001"]
+    assert quarantine["record_id"].tolist() == ["source_row_000002"]
+    assert candidate_pool["record_id"].tolist() == ["source_row_000001"]


### PR DESCRIPTION
## Summary
- Assign stable `source_row_000001`-style record IDs when source inputs do not provide `record_id`.
- Preserve existing record IDs when present and fill only blank IDs.
- Ensure verified, quarantine, candidate pool, and ranked candidate outputs remain traceable to source rows.

## Tests
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_run_verified_discovery_cli.py tests/test_evidence_cache_verifiers.py tests/test_real_data_authenticity.py tests/test_verified_dataset_builder.py tests/test_verified_candidate_discovery.py tests/test_verified_discovery_workflow.py tests/test_top_journal_reporting.py`
- `python -m py_compile hybrid_agent_exploration/src/data/verified_dataset_builder.py`

## TDD Evidence
- RED: `a863120 test: require stable source record ids`
- GREEN: `026bd76 feat: assign stable source record ids`

## Real Smoke Evidence
- Agent A/D real source-column smoke runs showed current real CSV lacks `record_id`, leaving ranked/audit candidates as blank/unknown. This PR fixes that provenance gap at the dataset builder layer.