### PR TITLE
feat: enforce verified candidate library contract

### DIFF
--- a/hybrid_agent_exploration/src/data/verified_dataset_builder.py
+++ b/hybrid_agent_exploration/src/data/verified_dataset_builder.py
@@ -26,9 +26,17 @@ from harness.authenticity import (
 ARTIFACT_POLICY = "verified-light-artifacts-in-git"
 DEFAULT_CANDIDATE_COLUMNS = (
     "record_id",
+    "candidate_id",
     "smiles",
     "pubchem_id",
     "cas_number",
+    "source_name",
+    "source_url",
+    "availability_status",
+    "synthesis_status",
+    "safety_status",
+    "vendor_name",
+    "vendor_catalog_id",
     "molecular_formula",
     "molecular_weight",
     "h_bond_donors",
@@ -189,8 +197,58 @@ def _candidate_pool(rows: list[dict[str, Any]], candidate_columns: Iterable[str]
         if key in seen:
             continue
         seen.add(key)
-        candidates.append({column: row.get(column) for column in columns if column in row})
+        candidates.append(_candidate_row(row, columns))
     return candidates
+
+
+def _candidate_row(row: dict[str, Any], columns: Iterable[str]) -> dict[str, Any]:
+    sources = _verification_sources(row)
+    molecule_source = _first_source({"verification_sources": sources}, "molecule")
+    reference_source = _first_source({"verification_sources": sources}, "reference")
+    primary_source = molecule_source or (sources[0] if sources else {})
+    defaults = {
+        "candidate_id": _text(row.get("candidate_id")) or _text(row.get("record_id")),
+        "source_name": _text(row.get("source_name")) or _text(primary_source.get("source")),
+        "source_url": _text(row.get("source_url")) or _candidate_source_url(row, molecule_source, reference_source),
+        "availability_status": _text(row.get("availability_status")) or "not_assessed",
+        "synthesis_status": _text(row.get("synthesis_status")) or "reported_in_literature",
+        "safety_status": _text(row.get("safety_status")) or "not_assessed",
+        "vendor_name": row.get("vendor_name"),
+        "vendor_catalog_id": row.get("vendor_catalog_id"),
+        "verification_sources": json.dumps(sources, ensure_ascii=False, sort_keys=True),
+    }
+    return {column: defaults.get(column, row.get(column)) for column in columns}
+
+
+def _candidate_source_url(
+    row: dict[str, Any],
+    molecule_source: dict[str, Any],
+    reference_source: dict[str, Any],
+) -> str:
+    for source in (molecule_source, reference_source):
+        url = _text(source.get("url"))
+        if url:
+            return url
+    pubchem_id = _text(row.get("pubchem_id"))
+    if pubchem_id:
+        return f"https://pubchem.ncbi.nlm.nih.gov/compound/{pubchem_id}"
+    doi = _text(row.get("doi"))
+    if doi:
+        return f"https://doi.org/{doi}"
+    return "verified_dataset"
+
+
+def _verification_sources(row: dict[str, Any]) -> list[dict[str, Any]]:
+    sources = row.get("verification_sources", [])
+    if isinstance(sources, str):
+        try:
+            parsed = json.loads(sources)
+        except json.JSONDecodeError:
+            return []
+        sources = parsed
+    if not isinstance(sources, list):
+        return []
+    return [source for source in sources if isinstance(source, dict)]
 
 
 def _doi_manifest(dataset_id: str, verified_rows: list[dict[str, Any]]) -> dict[str, Any]:
@@ -222,7 +280,7 @@ def _doi_manifest(dataset_id: str, verified_rows: list[dict[str, Any]]) -> dict[
 
 
 def _first_source(row: dict[str, Any], kind: str) -> dict[str, Any]:
-    for source in row.get("verification_sources", []):
+    for source in _verification_sources(row):
         if source.get("kind") == kind:
             return source
     return {}

--- a/hybrid_agent_exploration/src/run_verified_discovery.py
+++ b/hybrid_agent_exploration/src/run_verified_discovery.py
@@ -18,6 +18,7 @@ from harness.authenticity import (
     RealDataAuthenticator,
     ReferenceEvidence,
 )
+from screening.verified_candidate_discovery import CANDIDATE_LIBRARY_CONTRACT_VERSION
 from screening.verified_discovery_workflow import VerifiedDiscoveryWorkflow
 
 
@@ -131,6 +132,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--cache-dir",
         help="Evidence cache directory; defaults to hybrid_agent_exploration/.cache/verified_discovery/<dataset-id>/evidence_cache.",
     )
+    parser.add_argument(
+        "--candidate-pool",
+        help="Optional CSV/XLSX verified external candidate library to rank instead of the dataset-derived pool.",
+    )
     parser.add_argument("--top-k", type=int, default=100, help="Number of ranked candidates to emit.")
     parser.add_argument("--min-verified-rows", type=int, default=10, help="Minimum strict verified training rows.")
     parser.add_argument("--max-rows", type=int, help="Optional input row cap for smoke runs.")
@@ -150,7 +155,10 @@ def main(argv: list[str] | None = None) -> int:
         "source_columns_is_smoke_only": args.evidence_mode == "source-columns",
         "input_path": str(Path(args.input)),
         "max_rows": args.max_rows,
+        "candidate_pool_contract_version": CANDIDATE_LIBRARY_CONTRACT_VERSION,
     }
+    if args.candidate_pool:
+        run_metadata["candidate_pool_path"] = str(Path(args.candidate_pool))
     if args.evidence_mode == "external-cached":
         run_metadata["cache_dir"] = str(cache_dir)
     artifacts = VerifiedDiscoveryWorkflow(
@@ -162,6 +170,7 @@ def main(argv: list[str] | None = None) -> int:
         top_k=args.top_k,
         min_verified_rows=args.min_verified_rows,
         run_metadata=run_metadata,
+        candidate_pool=args.candidate_pool,
     )
     print(f"[verified-discovery] workflow_manifest={artifacts.workflow_manifest_json}")
     print(f"[verified-discovery] verified_rows={artifacts.verified_rows}")

--- a/hybrid_agent_exploration/src/screening/verified_candidate_discovery.py
+++ b/hybrid_agent_exploration/src/screening/verified_candidate_discovery.py
@@ -25,6 +25,24 @@ class UnverifiedCandidatePoolError(ValueError):
     """Raised when a candidate pool contains non-verified rows."""
 
 
+class CandidateLibraryContractError(ValueError):
+    """Raised when a candidate pool is not provenance-complete."""
+
+
+CANDIDATE_LIBRARY_CONTRACT_VERSION = "candidate-library-v1"
+CANDIDATE_LIBRARY_REQUIRED_COLUMNS = (
+    "candidate_id",
+    "smiles",
+    "source_name",
+    "source_url",
+    "availability_status",
+    "synthesis_status",
+    "safety_status",
+    "verification_status",
+    "verification_sources",
+)
+
+
 @dataclass(frozen=True)
 class CandidateDiscoveryArtifacts:
     """Paths and counts emitted by a verified candidate discovery run."""
@@ -56,6 +74,7 @@ class VerifiedCandidateDiscovery:
         """Rank a verified candidate pool and write discovery artifacts."""
 
         df = _load_candidate_pool(candidate_pool)
+        validate_candidate_library_contract(df)
         _require_verified(df)
         ranked = _rank_candidates(
             df,
@@ -96,6 +115,42 @@ def _load_candidate_pool(candidate_pool: pd.DataFrame | str | Path) -> pd.DataFr
     raise ValueError(f"Unsupported candidate pool format: {path.suffix}")
 
 
+def validate_candidate_library_contract(df: pd.DataFrame) -> None:
+    """Ensure candidate rows carry enough identity and provenance for ranking."""
+
+    missing = [column for column in CANDIDATE_LIBRARY_REQUIRED_COLUMNS if column not in df.columns]
+    if missing:
+        raise CandidateLibraryContractError(
+            "Candidate library contract missing required columns: " + ", ".join(missing)
+        )
+
+    empty_errors: list[str] = []
+    for column in CANDIDATE_LIBRARY_REQUIRED_COLUMNS:
+        empty = df[column].map(_text) == ""
+        if empty.any():
+            empty_errors.append(f"{column} empty for rows: {', '.join(_row_identifiers(df[empty]))}")
+    if empty_errors:
+        raise CandidateLibraryContractError("; ".join(empty_errors))
+
+    source_errors: list[str] = []
+    identity_errors: list[str] = []
+    for idx, row in df.iterrows():
+        sources = _parse_verification_sources(row.get("verification_sources"))
+        if not sources:
+            identifier = _row_identifiers(df.loc[[idx]])[0]
+            source_errors.append(f"{identifier} has empty verification_sources")
+            continue
+        has_identity = _text(row.get("pubchem_id")) or _text(row.get("cas_number"))
+        has_molecule_source = any(_text(source.get("kind")) == "molecule" for source in sources)
+        if not has_identity and not has_molecule_source:
+            identifier = _row_identifiers(df.loc[[idx]])[0]
+            identity_errors.append(f"{identifier} lacks molecule identity")
+    if source_errors:
+        raise CandidateLibraryContractError("; ".join(source_errors))
+    if identity_errors:
+        raise CandidateLibraryContractError("; ".join(identity_errors))
+
+
 def _require_verified(df: pd.DataFrame) -> None:
     if "verification_status" not in df.columns:
         raise UnverifiedCandidatePoolError(
@@ -114,9 +169,14 @@ def _require_verified(df: pd.DataFrame) -> None:
 
 
 def _row_identifiers(df: pd.DataFrame, limit: int = 10) -> list[str]:
+    if "candidate_id" in df.columns:
+        values = df["candidate_id"].fillna("").astype(str)
+        ids = [value.strip() for value in values.tolist() if value.strip()]
+        if ids:
+            return ids[:limit]
     if "record_id" in df.columns:
         values = df["record_id"].fillna("").astype(str)
-        ids = [value for value in values.tolist() if value]
+        ids = [value.strip() for value in values.tolist() if value.strip()]
     else:
         ids = [f"index:{idx}" for idx in df.index.tolist()]
     return ids[:limit]
@@ -173,6 +233,8 @@ def _manifest(
         "dataset_id": dataset_id,
         "generated_at": _now_iso(),
         "requires_verified_candidates": True,
+        "requires_verification_sources": True,
+        "candidate_library_contract_version": CANDIDATE_LIBRARY_CONTRACT_VERSION,
         "input_rows": artifacts.input_count,
         "ranked_rows": artifacts.ranked_count,
         "top_k": top_k,
@@ -196,6 +258,7 @@ def _audit_report(
         f"# Verified Candidate Discovery Audit: {dataset_id}",
         "",
         "- Gate: verified-only candidate pool (`verification_status=verified`).",
+        f"- Candidate library contract: `{CANDIDATE_LIBRARY_CONTRACT_VERSION}`.",
         f"- Input candidates: {artifacts.input_count}",
         f"- Ranked candidates emitted: {artifacts.ranked_count}",
         "",
@@ -206,7 +269,7 @@ def _audit_report(
         lines.append("- None")
     else:
         for _, row in ranked_df.head(10).iterrows():
-            record_id = _text(row.get("record_id")) or "unknown"
+            record_id = _text(row.get("candidate_id")) or _text(row.get("record_id")) or "unknown"
             smiles = _text(row.get("smiles")) or "unknown"
             score = row.get("predicted_delta_pce")
             lines.append(f"- {record_id}: `{smiles}` predicted_delta_pce={score}")
@@ -237,6 +300,20 @@ def _text(value: Any) -> str:
     except (TypeError, ValueError):
         pass
     return str(value).strip()
+
+
+def _parse_verification_sources(value: Any) -> list[dict[str, Any]]:
+    if isinstance(value, list):
+        return [source for source in value if isinstance(source, dict)]
+    if not _text(value):
+        return []
+    try:
+        parsed = json.loads(str(value))
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(parsed, list):
+        return []
+    return [source for source in parsed if isinstance(source, dict)]
 
 
 def _now_iso() -> str:

--- a/tests/test_run_verified_discovery_cli.py
+++ b/tests/test_run_verified_discovery_cli.py
@@ -98,3 +98,64 @@ def test_gitignore_excludes_verified_discovery_runtime_outputs():
     assert "hybrid_agent_exploration/results/verified_discovery_runs/" in gitignore
     assert "hybrid_agent_exploration/results/verified_discovery_smoke*/" in gitignore
     assert "**/evidence_cache/" in gitignore
+
+
+def test_cli_accepts_external_candidate_pool_path(tmp_path):
+    from run_verified_discovery import main
+
+    input_csv = tmp_path / "raw.csv"
+    candidate_csv = tmp_path / "external_candidates.csv"
+    output_dir = tmp_path / "out"
+    pd.DataFrame(
+        [
+            _record("row-001", "10.1021/acs.jpclett.6c00119", "C", 0.25),
+            _record("row-002", "10.1021/acs.jpclett.6c00120", "CC", 0.50),
+        ]
+    ).to_csv(input_csv, index=False)
+    pd.DataFrame(
+        [
+            {
+                "candidate_id": "external-001",
+                "smiles": "CCCC",
+                "pubchem_id": "7843",
+                "cas_number": "106-97-8",
+                "vendor_name": "TCI",
+                "vendor_catalog_id": "B0001",
+                "source_name": "vendor_catalog",
+                "source_url": "https://example.com/catalog/B0001",
+                "availability_status": "commercial",
+                "synthesis_status": "commercial",
+                "safety_status": "sds_available",
+                "verification_status": "verified",
+                "verification_sources": json.dumps([
+                    {"kind": "molecule", "source": "pubchem", "pubchem_id": "7843"}
+                ]),
+            }
+        ]
+    ).to_csv(candidate_csv, index=False)
+
+    exit_code = main(
+        [
+            "--input",
+            str(input_csv),
+            "--candidate-pool",
+            str(candidate_csv),
+            "--output-dir",
+            str(output_dir),
+            "--dataset-id",
+            "cli-external-candidate-fixture",
+            "--evidence-mode",
+            "source-columns",
+            "--min-verified-rows",
+            "2",
+            "--top-k",
+            "1",
+        ]
+    )
+
+    assert exit_code == 0
+    ranked = pd.read_csv(output_dir / "discovery" / "ranked_candidates.csv")
+    assert ranked["candidate_id"].tolist() == ["external-001"]
+    manifest = json.loads((output_dir / "workflow_manifest.json").read_text(encoding="utf-8"))
+    assert manifest["candidate_pool_path"] == str(candidate_csv)
+    assert manifest["candidate_pool_contract_version"] == "candidate-library-v1"

--- a/tests/test_verified_candidate_discovery.py
+++ b/tests/test_verified_candidate_discovery.py
@@ -44,6 +44,49 @@ def _verified_pool() -> pd.DataFrame:
     )
 
 
+def _external_candidate_pool() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "candidate_id": "cand-001",
+                "smiles": "CC",
+                "pubchem_id": "702",
+                "cas_number": "64-17-5",
+                "vendor_name": "Sigma Aldrich",
+                "vendor_catalog_id": "EtOH",
+                "source_name": "pubchem",
+                "source_url": "https://pubchem.ncbi.nlm.nih.gov/compound/702",
+                "availability_status": "commercial",
+                "synthesis_status": "commercial",
+                "safety_status": "sds_available",
+                "verification_status": "verified",
+                "verification_sources": json.dumps([
+                    {"kind": "molecule", "source": "pubchem", "pubchem_id": "702"},
+                    {"kind": "availability", "source": "vendor_catalog", "vendor_name": "Sigma Aldrich"},
+                ]),
+            },
+            {
+                "candidate_id": "cand-002",
+                "smiles": "CCCC",
+                "pubchem_id": "7843",
+                "cas_number": "106-97-8",
+                "vendor_name": "TCI",
+                "vendor_catalog_id": "B0001",
+                "source_name": "vendor_catalog",
+                "source_url": "https://example.com/catalog/B0001",
+                "availability_status": "commercial",
+                "synthesis_status": "commercial",
+                "safety_status": "sds_available",
+                "verification_status": "verified",
+                "verification_sources": json.dumps([
+                    {"kind": "molecule", "source": "pubchem", "pubchem_id": "7843"},
+                    {"kind": "availability", "source": "vendor_catalog", "vendor_name": "TCI"},
+                ]),
+            },
+        ]
+    )
+
+
 def test_discovery_ranks_verified_pool_and_writes_outputs(tmp_path):
     from screening.verified_candidate_discovery import VerifiedCandidateDiscovery
 
@@ -98,3 +141,83 @@ def test_discovery_refuses_quarantined_or_unverified_rows(tmp_path):
 
     assert "row-002" in str(exc.value)
     assert "verification_status=verified" in str(exc.value)
+
+
+def test_candidate_library_contract_refuses_missing_required_source_columns(tmp_path):
+    from screening.verified_candidate_discovery import CandidateLibraryContractError, VerifiedCandidateDiscovery
+
+    pool = _external_candidate_pool().drop(columns=["source_url"])
+
+    with pytest.raises(CandidateLibraryContractError) as exc:
+        VerifiedCandidateDiscovery(output_dir=tmp_path).discover(
+            pool,
+            model=LengthModel(),
+            feature_fn=_feature_fn,
+            dataset_id="missing-source-url",
+        )
+
+    assert "source_url" in str(exc.value)
+
+
+def test_candidate_library_contract_refuses_empty_verification_sources(tmp_path):
+    from screening.verified_candidate_discovery import CandidateLibraryContractError, VerifiedCandidateDiscovery
+
+    pool = _external_candidate_pool()
+    pool.loc[0, "verification_sources"] = "[]"
+
+    with pytest.raises(CandidateLibraryContractError) as exc:
+        VerifiedCandidateDiscovery(output_dir=tmp_path).discover(
+            pool,
+            model=LengthModel(),
+            feature_fn=_feature_fn,
+            dataset_id="empty-sources",
+        )
+
+    assert "verification_sources" in str(exc.value)
+    assert "cand-001" in str(exc.value)
+
+
+def test_candidate_library_contract_requires_identity_or_molecule_source(tmp_path):
+    from screening.verified_candidate_discovery import CandidateLibraryContractError, VerifiedCandidateDiscovery
+
+    pool = _external_candidate_pool()
+    pool.loc[0, ["pubchem_id", "cas_number"]] = ""
+    pool.loc[0, "verification_sources"] = json.dumps([
+        {"kind": "availability", "source": "vendor_catalog"}
+    ])
+
+    with pytest.raises(CandidateLibraryContractError) as exc:
+        VerifiedCandidateDiscovery(output_dir=tmp_path).discover(
+            pool,
+            model=LengthModel(),
+            feature_fn=_feature_fn,
+            dataset_id="missing-identity",
+        )
+
+    assert "molecule identity" in str(exc.value)
+    assert "cand-001" in str(exc.value)
+
+
+def test_discovery_ranks_verified_external_candidate_library(tmp_path):
+    from screening.verified_candidate_discovery import VerifiedCandidateDiscovery
+
+    artifacts = VerifiedCandidateDiscovery(output_dir=tmp_path).discover(
+        _external_candidate_pool(),
+        model=LengthModel(),
+        feature_fn=_feature_fn,
+        top_k=1,
+        dataset_id="external-candidates",
+    )
+
+    ranked = pd.read_csv(artifacts.ranked_candidates_csv)
+    assert ranked["candidate_id"].tolist() == ["cand-002"]
+    assert ranked["vendor_name"].tolist() == ["TCI"]
+    assert ranked["source_url"].tolist() == ["https://example.com/catalog/B0001"]
+    assert ranked["availability_status"].tolist() == ["commercial"]
+    assert ranked["synthesis_status"].tolist() == ["commercial"]
+    assert ranked["safety_status"].tolist() == ["sds_available"]
+    assert "pubchem" in ranked.loc[0, "verification_sources"]
+
+    manifest = json.loads(artifacts.discovery_manifest_json.read_text(encoding="utf-8"))
+    assert manifest["candidate_library_contract_version"] == "candidate-library-v1"
+    assert manifest["requires_verification_sources"] is True

--- a/tests/test_verified_candidate_discovery.py
+++ b/tests/test_verified_candidate_discovery.py
@@ -24,20 +24,38 @@ def _verified_pool() -> pd.DataFrame:
         [
             {
                 "record_id": "row-001",
+                "candidate_id": "row-001",
                 "smiles": "CC",
+                "pubchem_id": "702",
+                "cas_number": "64-17-5",
                 "doi": "10.1021/acs.jpclett.6c00119",
+                "source_name": "fixture-pubchem",
+                "source_url": "https://pubchem.ncbi.nlm.nih.gov/compound/702",
+                "availability_status": "not_assessed",
+                "synthesis_status": "reported_in_literature",
+                "safety_status": "not_assessed",
                 "verification_status": "verified",
                 "verification_sources": json.dumps([
-                    {"kind": "reference", "source": "fixture-crossref", "doi": "10.1021/acs.jpclett.6c00119"}
+                    {"kind": "reference", "source": "fixture-crossref", "doi": "10.1021/acs.jpclett.6c00119"},
+                    {"kind": "molecule", "source": "fixture-pubchem", "pubchem_id": "702"},
                 ]),
             },
             {
                 "record_id": "row-002",
+                "candidate_id": "row-002",
                 "smiles": "CCCC",
+                "pubchem_id": "7843",
+                "cas_number": "106-97-8",
                 "doi": "10.1021/acs.jpclett.6c00120",
+                "source_name": "fixture-pubchem",
+                "source_url": "https://pubchem.ncbi.nlm.nih.gov/compound/7843",
+                "availability_status": "not_assessed",
+                "synthesis_status": "reported_in_literature",
+                "safety_status": "not_assessed",
                 "verification_status": "verified",
                 "verification_sources": json.dumps([
-                    {"kind": "reference", "source": "fixture-crossref", "doi": "10.1021/acs.jpclett.6c00120"}
+                    {"kind": "reference", "source": "fixture-crossref", "doi": "10.1021/acs.jpclett.6c00120"},
+                    {"kind": "molecule", "source": "fixture-pubchem", "pubchem_id": "7843"},
                 ]),
             },
         ]

--- a/tests/test_verified_dataset_builder.py
+++ b/tests/test_verified_dataset_builder.py
@@ -78,6 +78,27 @@ def test_builder_writes_verified_training_quarantine_and_manifests(tmp_path):
     assert "missing_doi" in quarantine.loc[0, "quarantine_reason"]
     assert candidate_pool["record_id"].tolist() == ["row-001"]
     assert "row-002" not in set(candidate_pool["record_id"])
+    assert {
+        "candidate_id",
+        "source_name",
+        "source_url",
+        "availability_status",
+        "synthesis_status",
+        "safety_status",
+        "vendor_name",
+        "vendor_catalog_id",
+    }.issubset(candidate_pool.columns)
+    assert candidate_pool.loc[0, "candidate_id"] == "row-001"
+    assert candidate_pool.loc[0, "source_name"] == "fixture-pubchem"
+    assert candidate_pool.loc[0, "source_url"] == "https://pubchem.ncbi.nlm.nih.gov/compound/702"
+    assert candidate_pool.loc[0, "availability_status"] == "not_assessed"
+    assert candidate_pool.loc[0, "synthesis_status"] == "reported_in_literature"
+    assert candidate_pool.loc[0, "safety_status"] == "not_assessed"
+    assert pd.isna(candidate_pool.loc[0, "vendor_name"])
+    assert pd.isna(candidate_pool.loc[0, "vendor_catalog_id"])
+    verification_sources = json.loads(candidate_pool.loc[0, "verification_sources"])
+    assert verification_sources
+    assert verification_sources[0]["source"] == "fixture-crossref"
 
     doi_manifest = json.loads(artifacts.doi_manifest_json.read_text(encoding="utf-8"))
     assert doi_manifest["dataset_id"] == "fixture-additive-dataset"


### PR DESCRIPTION
## Summary
- add candidate-library-v1 contract validation before candidate ranking
- extend verified dataset-derived candidate pools with source/provenance/availability fields
- add --candidate-pool CLI support and workflow manifest metadata for external candidate libraries

## Validation
- RED: PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_verified_candidate_discovery.py tests/test_run_verified_discovery_cli.py -> 5 failed, 5 passed before implementation
- GREEN: PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_verified_dataset_builder.py tests/test_verified_candidate_discovery.py tests/test_run_verified_discovery_cli.py -> 13 passed
- Expanded: PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_verified_discovery_workflow.py tests/test_evidence_cache_verifiers.py tests/test_verified_dataset_builder.py tests/test_verified_candidate_discovery.py tests/test_run_verified_discovery_cli.py -> 20 passed
- Smoke: python hybrid_agent_exploration/src/run_verified_discovery.py --input /share/yhm/test/AutoML_EDA/hybrid_agent_exploration/explorations/data_source_exploration/.cache/merged_llm_crossref_data_streaming_with_chemical_data_fast.csv --output-dir hybrid_agent_exploration/results/verified_discovery_smoke_contract --dataset-id contract_smoke_500 --evidence-mode source-columns --max-rows 500 --top-k 50 --min-verified-rows 10 -> verified_rows=30, quarantine_rows=470, ranked_candidates=17