### PR TITLE
feat: ingest verified discovery provenance in reports

### DIFF
--- a/hybrid_agent_exploration/src/reporting/si_generator.py
+++ b/hybrid_agent_exploration/src/reporting/si_generator.py
@@ -18,6 +18,10 @@ from .figure_selector import FigureSelector
 from .image_embedder import embed_markdown_images
 from .shap_analyzer import SHAPAnalyzer
 from .molecular_plots import MolecularPlotter
+from .verified_discovery_ingestion import (
+    format_verified_discovery_markdown,
+    load_verified_discovery_summary,
+)
 
 
 class SIGenerator:
@@ -37,6 +41,7 @@ class SIGenerator:
         self.fg = FigureGenerator(self.fig_dir, "si")
         self.shap = SHAPAnalyzer(self.fig_dir)
         self.mol = MolecularPlotter(self.fig_dir)
+        self.verified_discovery = load_verified_discovery_summary(self.artifacts)
 
     def generate(self) -> Path:
         """Generate the complete SI document."""
@@ -78,6 +83,11 @@ class SIGenerator:
             lines.append(f"**Figure S{i}**. {caption}")
             lines.append("")
             lines.append(f"![{rel}](figures/{rel})")
+            lines.append("")
+
+        if self.verified_discovery:
+            lines.append("## S9. Verified Discovery Provenance")
+            lines.append(format_verified_discovery_markdown(self.verified_discovery))
             lines.append("")
 
         lines.append("---")

--- a/hybrid_agent_exploration/src/reporting/top_journal_report.py
+++ b/hybrid_agent_exploration/src/reporting/top_journal_report.py
@@ -26,6 +26,10 @@ from .narrative_engine import NarrativeEngine
 from .plan_registry import PlanRegistry, build_report_plan_context, load_plan_registry
 from .report_bundle import ReportBundle
 from .research_crew import ClaimAuditorAgent, ReviewerAgent
+from .verified_discovery_ingestion import (
+    format_verified_discovery_markdown,
+    load_verified_discovery_summary,
+)
 
 
 class TopJournalReport:
@@ -54,6 +58,7 @@ class TopJournalReport:
         self.fig_dir.mkdir(parents=True, exist_ok=True)
         self.selector = FigureSelector(self.artifacts)
         self.narrative = NarrativeEngine()
+        self.verified_discovery = load_verified_discovery_summary(self.artifacts)
 
     def generate(self) -> ReportBundle:
         """Generate the complete main-text report."""
@@ -677,6 +682,13 @@ class TopJournalReport:
             lines.append(f"![Figure {index}: {name}](figures/{rel})")
             lines.append("")
 
+        if self.verified_discovery:
+            lines.extend([
+                "### Verified Discovery Provenance",
+                format_verified_discovery_markdown(self.verified_discovery),
+                "",
+            ])
+
         lines.extend([
             "## 4. Limitations and Evidence Gaps",
             self._limitations(),
@@ -825,6 +837,21 @@ class TopJournalReport:
                 "evidence_id": f"figure:fig{index}",
                 "figure": str(Path("figures") / Path(path).name),
             })
+        if self.verified_discovery:
+            ledger.extend([
+                {
+                    "claim": "Number of top verified candidate records ingested into the report bundle",
+                    "evidence_id": "discovery:top_candidates.count",
+                    "value": len(self.verified_discovery.get("top_candidates", [])),
+                    "source": "discovery/ranked_candidates.csv",
+                },
+                {
+                    "claim": "Quarantine reason counts from verified discovery provenance",
+                    "evidence_id": "provenance:quarantine_reason_summary",
+                    "value": self.verified_discovery.get("quarantine_reason_summary", {}),
+                    "source": "dataset/quarantine.csv",
+                },
+            ])
         references = self._load_references()
         ledger.append({
             "claim": "Literature benchmark covers PSC, molecular ML, virtual screening, experimental validation, and database subfields",
@@ -869,6 +896,8 @@ class TopJournalReport:
         if plan_manifest is not None:
             manifest["plan_registry"] = plan_manifest
             manifest["agents"].insert(0, "PlanRegistryAgent")
+        if self.verified_discovery:
+            manifest["verified_discovery"] = self.verified_discovery
         return manifest
 
     def _quality_score(self, figure_count: int, review: dict[str, Any], audit: dict[str, Any]) -> float:

--- a/hybrid_agent_exploration/src/reporting/verified_discovery_ingestion.py
+++ b/hybrid_agent_exploration/src/reporting/verified_discovery_ingestion.py
@@ -1,0 +1,159 @@
+"""Ingest verified discovery artifacts for report provenance sidecars."""
+
+from __future__ import annotations
+
+import csv
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+DISCOVERY_DIR_KEY = "verified_discovery_artifact_dir"
+DISCOVERY_TOP_N_KEY = "verified_discovery_top_n"
+DEFAULT_TOP_N = 10
+
+
+def load_verified_discovery_summary(artifacts: dict[str, Any]) -> dict[str, Any] | None:
+    """Load a bounded report summary from a verified discovery artifact dir."""
+
+    artifact_dir_value = artifacts.get(DISCOVERY_DIR_KEY)
+    if not artifact_dir_value:
+        return None
+
+    artifact_dir = Path(artifact_dir_value)
+    top_n = _positive_int(artifacts.get(DISCOVERY_TOP_N_KEY), DEFAULT_TOP_N)
+    workflow_manifest = _read_json(artifact_dir / "workflow_manifest.json")
+    doi_manifest = _read_json(artifact_dir / "dataset" / "doi_manifest.json")
+    top_candidates = _read_top_candidates(
+        artifact_dir / "discovery" / "ranked_candidates.csv",
+        top_n=top_n,
+    )
+    quarantine_reason_summary = _read_quarantine_reason_summary(
+        artifact_dir / "dataset" / "quarantine.csv"
+    )
+
+    return {
+        "source_dir": str(artifact_dir),
+        "dataset_id": workflow_manifest.get("dataset_id"),
+        "artifact_policy": workflow_manifest.get("artifact_policy"),
+        "verified_rows": workflow_manifest.get("verified_rows"),
+        "quarantine_rows": workflow_manifest.get("quarantine_rows"),
+        "ranked_candidates": workflow_manifest.get("ranked_candidates"),
+        "top_k": workflow_manifest.get("top_k"),
+        "doi_reference_count": doi_manifest.get("reference_count", len(doi_manifest.get("references", []))),
+        "top_candidate_limit": top_n,
+        "top_candidates": top_candidates,
+        "quarantine_reason_summary": dict(sorted(quarantine_reason_summary.items())),
+    }
+
+
+def format_verified_discovery_markdown(summary: dict[str, Any] | None) -> str:
+    """Render bounded verified discovery provenance for reports and SI."""
+
+    if not summary:
+        return "Verified discovery artifact directory was not supplied."
+
+    lines = [
+        f"Artifact source: `{summary.get('source_dir')}`.",
+        (
+            f"Dataset `{summary.get('dataset_id')}` contained "
+            f"{summary.get('verified_rows')} verified rows and "
+            f"{summary.get('quarantine_rows')} quarantined rows before candidate ranking."
+        ),
+        f"DOI references in manifest: {summary.get('doi_reference_count')}.",
+        "",
+        "### Top Verified Candidates",
+        "",
+        "| Rank | Record ID | SMILES | Predicted Delta PCE | Uncertainty | DOI |",
+        "|------|-----------|--------|---------------------|-------------|-----|",
+    ]
+    candidates = summary.get("top_candidates", [])
+    if candidates:
+        for row in candidates:
+            lines.append(
+                "| {rank} | {record_id} | `{smiles}` | {score} | {uncertainty} | {doi} |".format(
+                    rank=_text(row.get("rank")) or "?",
+                    record_id=_text(row.get("record_id")) or "?",
+                    smiles=_text(row.get("smiles")) or "?",
+                    score=_format_float(row.get("predicted_delta_pce")),
+                    uncertainty=_format_float(row.get("uncertainty")),
+                    doi=_text(row.get("doi")) or "N/A",
+                )
+            )
+    else:
+        lines.append("| N/A | N/A | N/A | N/A | N/A | N/A |")
+
+    lines.extend(["", "### Quarantine Reason Summary", ""])
+    reasons = summary.get("quarantine_reason_summary", {})
+    if reasons:
+        lines.extend(f"- {reason}: {count}" for reason, count in sorted(reasons.items()))
+    else:
+        lines.append("- None")
+    return "\n".join(lines)
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(f"Verified discovery artifact missing: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _read_top_candidates(path: Path, *, top_n: int) -> list[dict[str, Any]]:
+    if not path.exists():
+        raise FileNotFoundError(f"Verified discovery artifact missing: {path}")
+    columns = ("rank", "record_id", "smiles", "predicted_delta_pce", "uncertainty", "doi", "verification_status")
+    rows: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        for row in csv.DictReader(handle):
+            rows.append({column: _coerce_cell(row.get(column, "")) for column in columns if column in row})
+            if len(rows) >= top_n:
+                break
+    return rows
+
+
+def _read_quarantine_reason_summary(path: Path) -> Counter[str]:
+    if not path.exists():
+        raise FileNotFoundError(f"Verified discovery artifact missing: {path}")
+    reasons: Counter[str] = Counter()
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        for row in csv.DictReader(handle):
+            for reason in _text(row.get("quarantine_reason")).split(";"):
+                reason = reason.strip()
+                if reason:
+                    reasons[reason] += 1
+    return reasons
+
+
+def _positive_int(value: Any, default: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _coerce_cell(value: Any) -> Any:
+    text = _text(value)
+    if text == "":
+        return ""
+    try:
+        number = float(text)
+    except ValueError:
+        return text
+    if number.is_integer() and "." not in text:
+        return int(number)
+    return number
+
+
+def _format_float(value: Any) -> str:
+    try:
+        return f"{float(value):.3f}"
+    except (TypeError, ValueError):
+        return "N/A"
+
+
+def _text(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()

--- a/hybrid_agent_exploration/src/reporting/verified_discovery_ingestion.py
+++ b/hybrid_agent_exploration/src/reporting/verified_discovery_ingestion.py
@@ -24,14 +24,30 @@ def load_verified_discovery_summary(artifacts: dict[str, Any]) -> dict[str, Any]
     artifact_dir = Path(artifact_dir_value)
     top_n = _positive_int(artifacts.get(DISCOVERY_TOP_N_KEY), DEFAULT_TOP_N)
     workflow_manifest = _read_json(artifact_dir / "workflow_manifest.json")
-    doi_manifest = _read_json(artifact_dir / "dataset" / "doi_manifest.json")
+    doi_manifest_path = _manifest_output_path(
+        artifact_dir,
+        workflow_manifest,
+        "doi_manifest_json",
+        "dataset/doi_manifest.json",
+    )
+    ranked_candidates_path = _manifest_output_path(
+        artifact_dir,
+        workflow_manifest,
+        "ranked_candidates_csv",
+        "discovery/ranked_candidates.csv",
+    )
+    quarantine_path = _manifest_output_path(
+        artifact_dir,
+        workflow_manifest,
+        "quarantine_csv",
+        "dataset/quarantine.csv",
+    )
+    doi_manifest = _read_json(doi_manifest_path)
     top_candidates = _read_top_candidates(
-        artifact_dir / "discovery" / "ranked_candidates.csv",
+        ranked_candidates_path,
         top_n=top_n,
     )
-    quarantine_reason_summary = _read_quarantine_reason_summary(
-        artifact_dir / "dataset" / "quarantine.csv"
-    )
+    quarantine_reason_summary = _read_quarantine_reason_summary(quarantine_path)
 
     return {
         "source_dir": str(artifact_dir),
@@ -45,6 +61,12 @@ def load_verified_discovery_summary(artifacts: dict[str, Any]) -> dict[str, Any]
         "top_candidate_limit": top_n,
         "top_candidates": top_candidates,
         "quarantine_reason_summary": dict(sorted(quarantine_reason_summary.items())),
+        "artifacts": {
+            "workflow_manifest_json": "workflow_manifest.json",
+            "ranked_candidates_csv": _relative_to_artifact_dir(ranked_candidates_path, artifact_dir),
+            "doi_manifest_json": _relative_to_artifact_dir(doi_manifest_path, artifact_dir),
+            "quarantine_csv": _relative_to_artifact_dir(quarantine_path, artifact_dir),
+        },
     }
 
 
@@ -97,6 +119,27 @@ def _read_json(path: Path) -> dict[str, Any]:
     if not path.exists():
         raise FileNotFoundError(f"Verified discovery artifact missing: {path}")
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _manifest_output_path(
+    artifact_dir: Path,
+    workflow_manifest: dict[str, Any],
+    key: str,
+    fallback: str,
+) -> Path:
+    outputs = workflow_manifest.get("outputs", {})
+    value = outputs.get(key, fallback) if isinstance(outputs, dict) else fallback
+    path = Path(str(value))
+    if path.is_absolute():
+        return path
+    return artifact_dir / path
+
+
+def _relative_to_artifact_dir(path: Path, artifact_dir: Path) -> str:
+    try:
+        return path.relative_to(artifact_dir).as_posix()
+    except ValueError:
+        return str(path)
 
 
 def _read_top_candidates(path: Path, *, top_n: int) -> list[dict[str, Any]]:

--- a/tests/test_top_journal_reporting.py
+++ b/tests/test_top_journal_reporting.py
@@ -76,6 +76,68 @@ def _sample_artifacts() -> dict:
     }
 
 
+def _write_verified_discovery_artifact_dir(root: Path) -> Path:
+    artifact_dir = root / "verified_discovery"
+    (artifact_dir / "discovery").mkdir(parents=True)
+    (artifact_dir / "dataset").mkdir(parents=True)
+    (artifact_dir / "workflow_manifest.json").write_text(
+        json.dumps(
+            {
+                "dataset_id": "verified-fixture",
+                "artifact_policy": "verified-light-artifacts-in-git",
+                "verified_rows": 12,
+                "quarantine_rows": 3,
+                "ranked_candidates": 3,
+                "top_k": 3,
+                "outputs": {
+                    "ranked_candidates_csv": "discovery/ranked_candidates.csv",
+                    "doi_manifest_json": "dataset/doi_manifest.json",
+                    "quarantine_csv": "dataset/quarantine.csv",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (artifact_dir / "discovery" / "ranked_candidates.csv").write_text(
+        "\n".join(
+            [
+                "rank,record_id,smiles,predicted_delta_pce,uncertainty,doi,verification_status",
+                "1,row-004,CCCC,1.25,0.10,10.1021/acs.jpclett.6c00122,verified",
+                "2,row-003,CCC,0.75,0.20,10.1021/acs.jpclett.6c00121,verified",
+                "3,row-002,CC,0.50,0.30,10.1021/acs.jpclett.6c00120,verified",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (artifact_dir / "dataset" / "doi_manifest.json").write_text(
+        json.dumps(
+            {
+                "dataset_id": "verified-fixture",
+                "reference_count": 2,
+                "references": [
+                    {"doi": "10.1021/acs.jpclett.6c00122", "title": "Verified source A"},
+                    {"doi": "10.1021/acs.jpclett.6c00121", "title": "Verified source B"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (artifact_dir / "dataset" / "quarantine.csv").write_text(
+        "\n".join(
+            [
+                "record_id,quarantine_reason",
+                "row-009,missing_doi",
+                "row-010,missing_doi;invalid_smiles",
+                "row-011,title_conflict",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return artifact_dir
+
+
 def test_top_journal_bundle_places_figures_in_context_and_records_claims(tmp_path):
     from reporting.report_bundle import ReportBundle
     from reporting.top_journal_report import TopJournalReport
@@ -110,6 +172,52 @@ def test_top_journal_bundle_places_figures_in_context_and_records_claims(tmp_pat
     review = json.loads((tmp_path / "review_report.json").read_text(encoding="utf-8"))
     assert review["review"]["passed"] is True
     assert review["claim_audit"]["passed"] is True
+
+
+def test_report_bundle_ingests_verified_discovery_provenance_without_manuscript_dependency(tmp_path):
+    from reporting.si_generator import SIGenerator
+    from reporting.top_journal_report import TopJournalReport
+
+    artifact_dir = _write_verified_discovery_artifact_dir(tmp_path)
+    artifacts = {
+        **_sample_artifacts(),
+        "verified_discovery_artifact_dir": artifact_dir,
+        "verified_discovery_top_n": 2,
+    }
+
+    bundle = TopJournalReport(
+        _sample_results(),
+        artifacts,
+        output_dir=tmp_path / "report",
+        quality_target="top-journal",
+    ).generate()
+    si_path = SIGenerator(
+        _sample_results(),
+        artifacts,
+        output_dir=tmp_path / "si",
+    ).generate()
+
+    manifest = json.loads(bundle.manifest_path.read_text(encoding="utf-8"))
+    discovery = manifest["verified_discovery"]
+    assert discovery["dataset_id"] == "verified-fixture"
+    assert discovery["source_dir"] == str(artifact_dir)
+    assert [row["record_id"] for row in discovery["top_candidates"]] == ["row-004", "row-003"]
+    assert "row-002" not in json.dumps(discovery)
+    assert discovery["quarantine_reason_summary"] == {
+        "invalid_smiles": 1,
+        "missing_doi": 2,
+        "title_conflict": 1,
+    }
+
+    evidence_ids = {entry["evidence_id"] for entry in bundle.claim_ledger}
+    assert "discovery:top_candidates.count" in evidence_ids
+    assert "provenance:quarantine_reason_summary" in evidence_ids
+
+    si_text = si_path.read_text(encoding="utf-8")
+    assert "## S9. Verified Discovery Provenance" in si_text
+    assert "| 1 | row-004 | `CCCC` | 1.250 | 0.100 | 10.1021/acs.jpclett.6c00122 |" in si_text
+    assert "row-002" not in si_text
+    assert "- missing_doi: 2" in si_text
 
 
 def test_embed_markdown_images_replaces_local_figure_links(tmp_path):


### PR DESCRIPTION
## Summary
- add a verified discovery artifact ingestion helper for workflow, ranked candidate, DOI, and quarantine provenance outputs
- include bounded verified discovery provenance in top-journal report manifest, claim ledger, main text, and SI
- resolve artifact paths through workflow_manifest.outputs so generated workflow layouts remain source-of-truth

## Validation
- RED: PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_top_journal_reporting.py -> KeyError: 'verified_discovery' before implementation
- GREEN: PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_top_journal_reporting.py -> 9 passed
- Expanded: PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_top_journal_reporting.py tests/test_verified_discovery_workflow.py -> 11 passed
- Compile: python -m py_compile hybrid_agent_exploration/src/reporting/verified_discovery_ingestion.py hybrid_agent_exploration/src/reporting/top_journal_report.py hybrid_agent_exploration/src/reporting/si_generator.py