### PR TITLE
feat: add baseline-aware candidate scoring

### DIFF
--- a/hybrid_agent_exploration/src/screening/verified_candidate_discovery.py
+++ b/hybrid_agent_exploration/src/screening/verified_candidate_discovery.py
@@ -30,6 +30,7 @@ class CandidateLibraryContractError(ValueError):
 
 
 CANDIDATE_LIBRARY_CONTRACT_VERSION = "candidate-library-v1"
+SCORING_POLICY_VERSION = "baseline-aware-candidate-scoring-v1"
 CANDIDATE_LIBRARY_REQUIRED_COLUMNS = (
     "candidate_id",
     "smiles",
@@ -205,7 +206,16 @@ def _rank_candidates(
     ranked["predicted_delta_pce"] = predictions
     if uncertainty_fn is not None:
         ranked["uncertainty"] = np.asarray(uncertainty_fn(model, X), dtype=float)
-    ranked = ranked.sort_values("predicted_delta_pce", ascending=False).reset_index(drop=True)
+    scored = ranked.apply(_candidate_score_components, axis=1)
+    ranked["candidate_score"] = [components["candidate_score"] for components in scored]
+    ranked["score_components"] = [
+        json.dumps(components, ensure_ascii=False, sort_keys=True)
+        for components in scored
+    ]
+    ranked = ranked.sort_values(
+        ["candidate_score", "predicted_delta_pce"],
+        ascending=[False, False],
+    ).reset_index(drop=True)
     ranked["rank"] = np.arange(1, len(ranked) + 1)
     return ranked.head(top_k).reset_index(drop=True)
 
@@ -235,6 +245,8 @@ def _manifest(
         "requires_verified_candidates": True,
         "requires_verification_sources": True,
         "candidate_library_contract_version": CANDIDATE_LIBRARY_CONTRACT_VERSION,
+        "scoring_policy_version": SCORING_POLICY_VERSION,
+        "scoring_policy": _scoring_policy(),
         "input_rows": artifacts.input_count,
         "ranked_rows": artifacts.ranked_count,
         "top_k": top_k,
@@ -285,6 +297,105 @@ def _audit_report(
         ]
     )
     return "\n".join(lines)
+
+
+def _candidate_score_components(row: pd.Series) -> dict[str, float | int]:
+    predicted_delta_pce = _number(row.get("predicted_delta_pce"))
+    baseline_pce = _number(row.get("baseline_pce"))
+    baseline_pce_bonus = _baseline_pce_bonus(baseline_pce)
+    baseline_context_bonus = 0.10 if _text(row.get("baseline_context")) else 0.0
+    availability_bonus = _status_bonus(
+        row.get("availability_status"),
+        positive={"commercial", "available", "in_stock", "vendor_confirmed"},
+        negative={"unavailable", "discontinued", "not_available"},
+        positive_bonus=0.20,
+        negative_penalty=-0.25,
+    )
+    synthesis_bonus = _status_bonus(
+        row.get("synthesis_status"),
+        positive={"commercial", "reported_in_literature", "reported_protocol", "known", "available"},
+        negative={"not_reported", "unknown", "failed", "unavailable"},
+        positive_bonus=0.15,
+        negative_penalty=-0.15,
+    )
+    safety_bonus = _status_bonus(
+        row.get("safety_status"),
+        positive={"sds_available", "low_hazard", "acceptable", "available"},
+        negative={"hazardous", "restricted", "not_recommended"},
+        positive_bonus=0.15,
+        negative_penalty=-0.30,
+    )
+    verification_evidence_count = len(_parse_verification_sources(row.get("verification_sources")))
+    verification_evidence_bonus = min(verification_evidence_count, 5) * 0.05
+    uncertainty = _number(row.get("uncertainty"))
+    uncertainty_penalty = -0.50 * uncertainty if uncertainty > 0 else 0.0
+    candidate_score = (
+        predicted_delta_pce
+        + baseline_pce_bonus
+        + baseline_context_bonus
+        + availability_bonus
+        + synthesis_bonus
+        + safety_bonus
+        + verification_evidence_bonus
+        + uncertainty_penalty
+    )
+    return {
+        "predicted_delta_pce": round(predicted_delta_pce, 6),
+        "baseline_pce": round(baseline_pce, 6) if baseline_pce > 0 else 0.0,
+        "baseline_pce_bonus": round(baseline_pce_bonus, 6),
+        "baseline_context_bonus": round(baseline_context_bonus, 6),
+        "availability_bonus": round(availability_bonus, 6),
+        "synthesis_bonus": round(synthesis_bonus, 6),
+        "safety_bonus": round(safety_bonus, 6),
+        "verification_evidence_count": verification_evidence_count,
+        "verification_evidence_bonus": round(verification_evidence_bonus, 6),
+        "uncertainty_penalty": round(uncertainty_penalty, 6),
+        "candidate_score": round(candidate_score, 6),
+    }
+
+
+def _baseline_pce_bonus(value: float) -> float:
+    if value <= 0:
+        return 0.0
+    return min(max((value - 18.0) * 0.02, 0.0), 0.20)
+
+
+def _status_bonus(
+    value: Any,
+    *,
+    positive: set[str],
+    negative: set[str],
+    positive_bonus: float,
+    negative_penalty: float,
+) -> float:
+    status = _text(value).lower()
+    if status in positive:
+        return positive_bonus
+    if status in negative:
+        return negative_penalty
+    return 0.0
+
+
+def _number(value: Any) -> float:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    if not np.isfinite(number):
+        return 0.0
+    return number
+
+
+def _scoring_policy() -> dict[str, Any]:
+    return {
+        "version": SCORING_POLICY_VERSION,
+        "sort_key": "candidate_score",
+        "base_signal": "predicted_delta_pce",
+        "baseline_context": "baseline_pce and baseline_context add bounded context bonuses when present",
+        "readiness_statuses": "availability_status, synthesis_status, and safety_status add bounded bonuses or penalties",
+        "verification_evidence": "verification_sources contributes a capped evidence-count bonus",
+        "uncertainty_penalty": "applied_when_uncertainty_column_is_available",
+    }
 
 
 def _write_json(payload: dict[str, Any], path: Path) -> None:

--- a/tests/test_run_verified_discovery_cli.py
+++ b/tests/test_run_verified_discovery_cli.py
@@ -156,6 +156,13 @@ def test_cli_accepts_external_candidate_pool_path(tmp_path):
     assert exit_code == 0
     ranked = pd.read_csv(output_dir / "discovery" / "ranked_candidates.csv")
     assert ranked["candidate_id"].tolist() == ["external-001"]
+    assert "candidate_score" in ranked.columns
+    assert "score_components" in ranked.columns
+    discovery_manifest = json.loads(
+        (output_dir / "discovery" / "candidate_discovery_manifest.json").read_text(encoding="utf-8")
+    )
+    assert discovery_manifest["scoring_policy_version"] == "baseline-aware-candidate-scoring-v1"
+    assert discovery_manifest["scoring_policy"]["sort_key"] == "candidate_score"
     manifest = json.loads((output_dir / "workflow_manifest.json").read_text(encoding="utf-8"))
     assert manifest["candidate_pool_path"] == str(candidate_csv)
     assert manifest["candidate_pool_contract_version"] == "candidate-library-v1"

--- a/tests/test_verified_candidate_discovery.py
+++ b/tests/test_verified_candidate_discovery.py
@@ -239,3 +239,59 @@ def test_discovery_ranks_verified_external_candidate_library(tmp_path):
     manifest = json.loads(artifacts.discovery_manifest_json.read_text(encoding="utf-8"))
     assert manifest["candidate_library_contract_version"] == "candidate-library-v1"
     assert manifest["requires_verification_sources"] is True
+
+
+def test_discovery_scores_candidates_with_baseline_evidence_and_readiness_context(tmp_path):
+    from screening.verified_candidate_discovery import VerifiedCandidateDiscovery
+
+    pool = _external_candidate_pool()
+    pool.loc[0, "baseline_pce"] = 22.0
+    pool.loc[0, "baseline_context"] = "matched FA/MA PbI3 control"
+    pool.loc[0, "verification_sources"] = json.dumps([
+        {"kind": "molecule", "source": "pubchem", "pubchem_id": "702"},
+        {"kind": "availability", "source": "vendor_catalog", "vendor_name": "Sigma Aldrich"},
+        {"kind": "synthesis", "source": "reported_protocol"},
+        {"kind": "safety", "source": "sds"},
+    ])
+    pool.loc[1, "baseline_pce"] = 16.0
+    pool.loc[1, "baseline_context"] = ""
+    pool.loc[1, "availability_status"] = "not_assessed"
+    pool.loc[1, "synthesis_status"] = "not_assessed"
+    pool.loc[1, "safety_status"] = "not_assessed"
+    pool.loc[1, "verification_sources"] = json.dumps([
+        {"kind": "molecule", "source": "pubchem", "pubchem_id": "7843"}
+    ])
+
+    def uncertainty_fn(model, features):
+        return [0.05, 1.2]
+
+    artifacts = VerifiedCandidateDiscovery(output_dir=tmp_path).discover(
+        pool,
+        model=LengthModel(),
+        feature_fn=_feature_fn,
+        top_k=2,
+        dataset_id="baseline-aware-scoring-fixture",
+        uncertainty_fn=uncertainty_fn,
+    )
+
+    ranked = pd.read_csv(artifacts.ranked_candidates_csv)
+    assert ranked["candidate_id"].tolist() == ["cand-001", "cand-002"]
+    assert ranked["predicted_delta_pce"].tolist() == [0.5, 1.0]
+    assert "candidate_score" in ranked.columns
+    assert "score_components" in ranked.columns
+    assert ranked.loc[0, "candidate_score"] > ranked.loc[1, "candidate_score"]
+
+    components = json.loads(ranked.loc[0, "score_components"])
+    assert components["predicted_delta_pce"] == 0.5
+    assert components["baseline_context_bonus"] > 0
+    assert components["availability_bonus"] > 0
+    assert components["synthesis_bonus"] > 0
+    assert components["safety_bonus"] > 0
+    assert components["verification_evidence_count"] == 4
+    assert components["verification_evidence_bonus"] > 0
+    assert components["uncertainty_penalty"] < 0
+
+    manifest = json.loads(artifacts.discovery_manifest_json.read_text(encoding="utf-8"))
+    assert manifest["scoring_policy_version"] == "baseline-aware-candidate-scoring-v1"
+    assert manifest["scoring_policy"]["sort_key"] == "candidate_score"
+    assert manifest["scoring_policy"]["uncertainty_penalty"] == "applied_when_uncertainty_column_is_available"


### PR DESCRIPTION
## Summary
- rank verified candidates by candidate_score instead of raw predicted_delta_pce alone
- add score_components JSON covering predicted_delta_pce, baseline context, readiness statuses, verification evidence count, and uncertainty penalty
- record scoring_policy_version and policy metadata in candidate discovery manifests

## Validation
- RED: new baseline-aware scoring test failed before implementation because candidate_score/score_components/scoring_policy were absent
- GREEN: PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_verified_candidate_discovery.py tests/test_run_verified_discovery_cli.py -> 11 passed
- Compile: python -m py_compile hybrid_agent_exploration/src/screening/verified_candidate_discovery.py