### PR TITLE
feat: run complete verified research packages

### DIFF
--- a/hybrid_agent_exploration/src/reporting/si_generator.py
+++ b/hybrid_agent_exploration/src/reporting/si_generator.py
@@ -48,6 +48,12 @@ class SIGenerator:
         lines = []
         lines.append("# Supporting Information")
         lines.append("")
+        evidence_note = self._evidence_context_section()
+        if evidence_note:
+            lines.append("## S0. Evidence Context")
+            lines.append(evidence_note)
+            lines.append("")
+
         lines.append("## S1. Data Cleaning and Quality Control")
         lines.append(self._data_cleaning_section())
         lines.append("")
@@ -281,7 +287,13 @@ class SIGenerator:
         successful = [r for r in self.results if r.get("status") == "success" and "r2" in r.get("metrics", {})]
         if not successful:
             return "No successful experiments."
-        lines = ["Performance metrics for all evaluated configurations:", ""]
+        if self._has_training_only_metrics():
+            lines = [
+                "Training-only fit metrics for verified-discovery model fits. These values are not cross-validation, scaffold-split, temporal-split, or independent external-validation metrics.",
+                "",
+            ]
+        else:
+            lines = ["Performance metrics for all evaluated configurations:", ""]
         lines.append("| Model | Feature | L1 | R² | RMSE | MAE | Pearson r | N | Features |")
         lines.append("|-------|---------|-----|-----|------|-----|-----------|---|----------|")
         for r in successful:
@@ -305,6 +317,11 @@ class SIGenerator:
         return "\n".join(lines)
 
     def _cv_section(self) -> str:
+        if self._has_training_only_metrics():
+            return (
+                "Cross-validation was not supplied for this research-package run. "
+                "The reported model metrics are training-only diagnostics and cannot establish generalization."
+            )
         cv_results = self.artifacts.get("cv_detailed_results", [])
         if cv_results:
             lines = ["Cross-validation results:", ""]
@@ -384,3 +401,33 @@ class SIGenerator:
                 pass
             return "\n".join(lines)
         return "SHAP analysis was not performed for this experiment set."
+
+    def _evidence_context_section(self) -> str:
+        context = self._evidence_context()
+        if not context:
+            return ""
+        lines = [
+            f"Evidence mode: `{context.get('evidence_mode', 'unknown')}`.",
+            f"Verification level: `{context.get('verification_level', 'unknown')}`.",
+            f"Publication-grade flag: `{context.get('publication_grade', False)}`.",
+        ]
+        if context.get("source_columns_is_smoke_only"):
+            lines.append(
+                "This is a source-columns smoke-only package: DOI and molecule evidence were accepted from input columns rather than rechecked through external services."
+            )
+        if context.get("metric_scope") == "training_only":
+            lines.append("Model metrics in this package are training-only diagnostics.")
+        return "\n".join(lines)
+
+    def _evidence_context(self) -> dict[str, Any]:
+        value = self.artifacts.get("evidence_context")
+        return value if isinstance(value, dict) else {}
+
+    def _has_training_only_metrics(self) -> bool:
+        context = self._evidence_context()
+        if context.get("metric_scope") == "training_only":
+            return True
+        return any(
+            row.get("metrics", {}).get("metric_scope") == "training_only"
+            for row in self.results
+        )

--- a/hybrid_agent_exploration/src/reporting/top_journal_report.py
+++ b/hybrid_agent_exploration/src/reporting/top_journal_report.py
@@ -693,7 +693,7 @@ class TopJournalReport:
             "## 4. Limitations and Evidence Gaps",
             self._limitations(),
             "",
-            self.narrative.conclusion(self.results),
+            self._conclusion(best_result),
             "",
             "## References",
             self._reference_section(),
@@ -704,6 +704,9 @@ class TopJournalReport:
         return "\n".join(lines)
 
     def _abstract(self, metrics: dict, config: dict, n_models: int) -> str:
+        if self._has_training_only_metrics():
+            return self._training_only_abstract(metrics, config, n_models)
+
         target = config.get("target", "delta_pce")
         r2 = metrics.get("r2")
         rmse = metrics.get("rmse")
@@ -725,12 +728,53 @@ class TopJournalReport:
             "The report embeds all generated figures in context and records each quantitative claim in a machine-readable claim ledger."
         )
 
+    def _training_only_abstract(self, metrics: dict, config: dict, n_models: int) -> str:
+        target = config.get("target", "delta_pce")
+        model = config.get("layer3", {}).get("method_id", "model")
+        r2 = metrics.get("r2")
+        rmse = metrics.get("rmse")
+        mae = metrics.get("mae")
+        metric_sentence = "No training metric summary is available."
+        if r2 is not None:
+            metric_sentence = f"The {model} fit reached a training-only $R^2$ = {r2:.3f}"
+            if rmse is not None:
+                metric_sentence += f", RMSE = {rmse:.3f}"
+            if mae is not None:
+                metric_sentence += f", and MAE = {mae:.3f}"
+            metric_sentence += "."
+        verification_note = (
+            "The source-columns mode is marked smoke-only because evidence was accepted from source table columns rather than rechecked through external DOI and molecule services. "
+            if self._is_source_columns_smoke()
+            else ""
+        )
+        return (
+            f"We report an evidence-audited exploratory QSPR package for predicting {target} in perovskite solar-cell additive data. "
+            f"The package contains {n_models} converged verified-discovery model fit, a verified candidate table, report sidecars, and provenance manifests. "
+            f"{metric_sentence} These metrics are training-only fit diagnostics and are not presented as validation, external validation, or chemical generalization evidence. "
+            f"{verification_note}"
+            "The report records supported claims in a machine-readable claim ledger and explicitly separates artifact availability from scientific validation."
+        )
+
     def _results_overview(self, best_result: dict | None) -> str:
         successful = self._successful_results()
         if not successful or not best_result:
             return "No successful experiments were available for the main results narrative."
         best = best_result["metrics"]
         cfg = best_result.get("config", {})
+        if self._has_training_only_metrics():
+            smoke_note = (
+                "The source-columns evidence mode is smoke-only and must be replaced by external-cached verification before publication-grade claims are made. "
+                if self._is_source_columns_smoke()
+                else ""
+            )
+            return (
+                f"The verified-discovery package contains {len(successful)} successful training-only model fit. "
+                f"The run used {cfg.get('layer2', {}).get('method_id', 'unknown')} features and "
+                f"{cfg.get('layer3', {}).get('method_id', 'unknown')} with training-only $R^2$ = {best.get('r2', 0):.3f}. "
+                "This value is a fit diagnostic from the verified training rows, not a random-split, scaffold-split, temporal-split, or external-validation result. "
+                f"{smoke_note}"
+                "Candidate ranking is therefore interpreted as a reproducibility and provenance check rather than a validated design rule."
+            )
         split_counts = {}
         for row in successful:
             split = row.get("config", {}).get("layer4", {}).get("method_id", "unknown")
@@ -774,6 +818,18 @@ class TopJournalReport:
         return captions.get(figure_name, self.narrative.figure_caption(figure_name, {}))
 
     def _limitations(self) -> str:
+        if self._has_training_only_metrics():
+            source_note = (
+                "Source-columns mode uses DOI and molecule fields already present in the input table and is explicitly smoke-only. "
+                if self._is_source_columns_smoke()
+                else "External-cached evidence checks are recorded separately from model validation. "
+            )
+            return (
+                f"{source_note}"
+                "The reported model metrics are training-only diagnostics and cannot establish predictive generalization. "
+                "No scaffold-split, temporal-split, independent external-validation, or experimental follow-up evidence is inferred unless those artifacts are supplied. "
+                "Mechanistic statements are limited to artifact availability and aggregate diagnostics; candidate rankings require external validation before they can be used as design rules."
+            )
         has_external = bool(self.artifacts.get("y_true_external") and self.artifacts.get("y_pred_external"))
         external_note = (
             "Independent external validation artifacts were available and are reported as diagnostics."
@@ -784,6 +840,31 @@ class TopJournalReport:
             "The analysis is bounded by the size and composition of the available experiment table. "
             "Random splits can overestimate generalization when structural analogues occur across train and test partitions, making scaffold split diagnostics essential. "
             f"{external_note} Mechanistic statements are limited to associations supported by model diagnostics and should be tested experimentally before use as design rules."
+        )
+
+    def _conclusion(self, best_result: dict | None) -> str:
+        if not self._has_training_only_metrics():
+            return self.narrative.conclusion(self.results)
+
+        best_metrics = best_result.get("metrics", {}) if best_result else {}
+        r2 = best_metrics.get("r2")
+        if r2 is None:
+            metric_sentence = "No successful training metric was available."
+        else:
+            metric_sentence = f"The current package records a training-only $R^2$ = {r2:.3f}, which is treated only as a fit diagnostic."
+        smoke_sentence = (
+            "Because this run used source-columns mode, it is a smoke package rather than a publication-grade verification package. "
+            if self._is_source_columns_smoke()
+            else ""
+        )
+        return "\n".join(
+            [
+                "## Conclusion",
+                "",
+                "This research package demonstrates that the verified-discovery artifact chain can produce a traceable dataset, candidate library, ranked candidates, manuscript text, SI, and provenance manifests from real input records.",
+                f"{metric_sentence} {smoke_sentence}The package does not support claims about representation superiority, baseline-feature benefit, SHAP-derived mechanisms, scaffold generalization, or externally validated candidate performance unless those artifacts are added in a future run.",
+                "The next scientific step is to replace smoke evidence with external-cached DOI and molecule verification, add held-out validation protocols, and connect top candidates to independently verifiable experimental or supplier evidence.",
+            ]
         )
 
     def _build_claim_ledger(self, figure_paths: list[tuple[str, Path]], best_result: dict | None) -> list[dict[str, Any]]:
@@ -852,6 +933,14 @@ class TopJournalReport:
                     "source": "dataset/quarantine.csv",
                 },
             ])
+        evidence_context = self._evidence_context()
+        if evidence_context:
+            ledger.append({
+                "claim": "Research package evidence context and smoke status",
+                "evidence_id": "provenance:research_package.evidence_context",
+                "value": evidence_context,
+                "source": "artifacts.evidence_context",
+            })
         references = self._load_references()
         ledger.append({
             "claim": "Literature benchmark covers PSC, molecular ML, virtual screening, experimental validation, and database subfields",
@@ -898,6 +987,9 @@ class TopJournalReport:
             manifest["agents"].insert(0, "PlanRegistryAgent")
         if self.verified_discovery:
             manifest["verified_discovery"] = self.verified_discovery
+        evidence_context = self._evidence_context()
+        if evidence_context:
+            manifest["evidence_context"] = evidence_context
         return manifest
 
     def _quality_score(self, figure_count: int, review: dict[str, Any], audit: dict[str, Any]) -> float:
@@ -967,7 +1059,38 @@ class TopJournalReport:
     def _has_shap_artifacts(self) -> bool:
         return bool(self.artifacts.get("shap_values") and self.artifacts.get("shap_background"))
 
+    def _evidence_context(self) -> dict[str, Any]:
+        value = self.artifacts.get("evidence_context")
+        return value if isinstance(value, dict) else {}
+
+    def _is_source_columns_smoke(self) -> bool:
+        context = self._evidence_context()
+        return bool(context.get("source_columns_is_smoke_only"))
+
+    def _has_training_only_metrics(self) -> bool:
+        context = self._evidence_context()
+        if context.get("metric_scope") == "training_only":
+            return True
+        return any(
+            row.get("metrics", {}).get("metric_scope") == "training_only"
+            for row in self.results
+        )
+
     def _introduction(self) -> str:
+        if self._has_training_only_metrics():
+            smoke_note = (
+                "This source-columns package is a smoke run: DOI and molecule evidence were accepted from the input columns rather than rechecked through external services. "
+                if self._is_source_columns_smoke()
+                else "External evidence checks are recorded in the package manifests, but model metrics remain training-only. "
+            )
+            return (
+                "Accurate prediction of power-conversion-efficiency (PCE) modulation by molecular additives "
+                "requires both trustworthy source records and validation protocols that test chemical generalization. "
+                "This package focuses on the reproducible artifact chain needed for that study: strict row verification, "
+                "candidate-library normalization, training-set model fitting, candidate ranking, manuscript sidecars, and provenance manifests. "
+                f"{smoke_note}"
+                "The generated text therefore treats all model metrics as training-only diagnostics and reserves scientific design-rule claims for future runs with validation artifacts."
+            )
         interpretation_sentence = (
             "Available SHAP diagnostics are used to describe model associations while avoiding causal mechanistic claims. "
             if self._has_shap_artifacts()
@@ -996,6 +1119,22 @@ class TopJournalReport:
         l2s = set(r.get("config", {}).get("layer2", {}).get("method_id", "?") for r in successful)
         l3s = set(r.get("config", {}).get("layer3", {}).get("method_id", "?") for r in successful)
         l4s = set(r.get("config", {}).get("layer4", {}).get("method_id", "?") for r in successful)
+
+        if self._has_training_only_metrics():
+            lines = [
+                "### Data Collection and Curation",
+                f"Data were curated with {', '.join(sorted(l1s))}. Rows lacking required DOI, molecule, or target fields were quarantined rather than used for model fitting.",
+                "",
+                "### Feature Engineering",
+                f"The package used the run-declared molecular representation(s): {', '.join(sorted(l2s))}. No additional Morgan, SHAP, or baseline-feature comparisons are inferred unless corresponding artifacts are supplied.",
+                "",
+                "### Model Fitting and Candidate Ranking",
+                f"Model class(es) recorded in the package: {', '.join(sorted(l3s))}. Metrics emitted by this runner are training-only diagnostics from verified rows. Candidate ranking uses the validated candidate-library contract and records score components in the discovery manifest.",
+                "",
+                "### Validation Status",
+                "No cross-validation, scaffold-split, temporal-split, independent external-validation, or experimental follow-up metric is inferred from this runner output. External evidence and model validation must be added as explicit artifacts before publication-grade claims are made.",
+            ]
+            return "\n".join(lines)
 
         lines = [
             "### Data Collection and Curation",

--- a/hybrid_agent_exploration/src/run_research_package.py
+++ b/hybrid_agent_exploration/src/run_research_package.py
@@ -1,0 +1,296 @@
+"""Run the verified PSC candidate-discovery research package.
+
+This CLI connects the verified dataset/discovery workflow, optional external
+candidate-library normalization, report/SI generation, and root provenance
+manifest into one reproducible artifact directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from reporting.root_provenance_manifest import generate_root_provenance_manifest
+from reporting.si_generator import SIGenerator
+from reporting.top_journal_report import TopJournalReport
+from run_verified_discovery import build_authenticator, default_cache_dir, load_input
+from screening.candidate_library_builder import CandidateLibraryBuilder
+from screening.verified_candidate_discovery import CANDIDATE_LIBRARY_CONTRACT_VERSION
+from screening.verified_discovery_workflow import VerifiedDiscoveryWorkflow
+
+
+@dataclass(frozen=True)
+class ResearchPackageArtifacts:
+    """Top-level paths emitted by a research package run."""
+
+    output_dir: Path
+    verified_discovery_dir: Path
+    candidate_library_dir: Path | None
+    report_dir: Path
+    root_provenance_manifest_json: Path
+    package_manifest_json: Path
+
+
+def run_research_package(
+    *,
+    input_path: str | Path,
+    output_dir: str | Path,
+    dataset_id: str,
+    evidence_mode: str = "external-cached",
+    candidate_source_path: str | Path | None = None,
+    candidate_source_name: str | None = None,
+    cache_dir: str | Path | None = None,
+    max_rows: int | None = None,
+    min_verified_rows: int = 10,
+    top_k: int = 100,
+    report_quality_target: str = "top-journal",
+    verified_discovery_top_n: int | None = None,
+) -> ResearchPackageArtifacts:
+    """Generate the full verified-discovery research artifact package."""
+
+    output_root = Path(output_dir)
+    output_root.mkdir(parents=True, exist_ok=True)
+    verified_discovery_dir = output_root / "verified_discovery"
+    report_dir = output_root / "report_bundle"
+
+    df = load_input(input_path, max_rows=max_rows)
+    cache_root = Path(cache_dir) if cache_dir else default_cache_dir(dataset_id)
+    authenticator = build_authenticator(evidence_mode, df, cache_root)
+
+    candidate_library_dir: Path | None = None
+    candidate_pool: Path | None = None
+    candidate_library_rows: int | None = None
+    if candidate_source_path is not None:
+        source_name = candidate_source_name or Path(candidate_source_path).stem
+        candidate_library_dir = output_root / "candidate_library"
+        candidate_artifacts = CandidateLibraryBuilder(output_dir=candidate_library_dir).build(
+            candidate_source_path,
+            dataset_id=dataset_id,
+            source_name=source_name,
+        )
+        candidate_pool = candidate_artifacts.candidate_library_csv
+        candidate_library_rows = candidate_artifacts.output_count
+
+    run_metadata = {
+        "evidence_mode": evidence_mode,
+        "verification_level": "external_cached" if evidence_mode == "external-cached" else "source_columns_only",
+        "publication_grade": evidence_mode == "external-cached",
+        "source_columns_is_smoke_only": evidence_mode == "source-columns",
+        "input_path": str(Path(input_path)),
+        "max_rows": max_rows,
+        "candidate_pool_contract_version": CANDIDATE_LIBRARY_CONTRACT_VERSION,
+        "research_package_runner": "run_research_package",
+    }
+    if evidence_mode == "external-cached":
+        run_metadata["cache_dir"] = str(cache_root)
+    if candidate_pool is not None:
+        run_metadata["candidate_pool_path"] = str(candidate_pool)
+
+    discovery_artifacts = VerifiedDiscoveryWorkflow(
+        output_dir=verified_discovery_dir,
+        authenticator=authenticator,
+    ).run_from_dataframe(
+        df,
+        dataset_id=dataset_id,
+        candidate_pool=candidate_pool,
+        top_k=top_k,
+        min_verified_rows=min_verified_rows,
+        run_metadata=run_metadata,
+    )
+
+    report_inputs = _report_inputs(
+        verified_discovery_dir,
+        top_n=verified_discovery_top_n or top_k,
+    )
+    main_bundle = TopJournalReport(
+        report_inputs["results"],
+        report_inputs["artifacts"],
+        output_dir=report_dir / "main_text",
+        quality_target=report_quality_target,
+    ).generate()
+    si_path = SIGenerator(
+        report_inputs["results"],
+        report_inputs["artifacts"],
+        output_dir=report_dir / "si",
+    ).generate()
+
+    root_manifest_path = output_root / "provenance_manifest.json"
+    generate_root_provenance_manifest(
+        verified_discovery_dir,
+        main_bundle.path.parent,
+        si_path.parent,
+        candidate_library_dir=candidate_library_dir,
+        output_path=root_manifest_path,
+    )
+
+    package_manifest_path = output_root / "package_manifest.json"
+    _write_json(
+        _package_manifest(
+            dataset_id=dataset_id,
+            output_root=output_root,
+            evidence_mode=evidence_mode,
+            discovery_artifacts=discovery_artifacts,
+            candidate_library_dir=candidate_library_dir,
+            candidate_library_rows=candidate_library_rows,
+            report_dir=report_dir,
+            report_quality_score=main_bundle.quality_score,
+            root_manifest_path=root_manifest_path,
+            package_manifest_path=package_manifest_path,
+        ),
+        package_manifest_path,
+    )
+    return ResearchPackageArtifacts(
+        output_dir=output_root,
+        verified_discovery_dir=verified_discovery_dir,
+        candidate_library_dir=candidate_library_dir,
+        report_dir=report_dir,
+        root_provenance_manifest_json=root_manifest_path,
+        package_manifest_json=package_manifest_path,
+    )
+
+
+def _report_inputs(verified_discovery_dir: Path, *, top_n: int) -> dict[str, Any]:
+    metrics = _read_json(verified_discovery_dir / "model" / "model_metrics.json")
+    workflow = _read_json(verified_discovery_dir / "workflow_manifest.json")
+    feature_columns = metrics.get("feature_columns", [])
+    result = {
+        "agent_id": "verified_discovery_model",
+        "status": "success",
+        "n_samples": metrics.get("train_rows", workflow.get("verified_rows", 0)),
+        "n_features": len(feature_columns),
+        "duration_sec": 0.0,
+        "config": {
+            "layer1": {"method_id": "strict_verified_data"},
+            "layer2": {"method_id": "default_smiles_features"},
+            "layer3": {"method_id": metrics.get("model_class", "model")},
+            "layer4": {"method_id": "verified_discovery_training"},
+            "layer5": {"method_id": "candidate_discovery_report"},
+            "target": metrics.get("target_column", "delta_pce"),
+            "baseline_as_feature": False,
+            "_hash": f"verified_discovery_{workflow.get('dataset_id', 'dataset')}",
+        },
+        "metrics": {
+            "r2": metrics.get("train_r2", 0.0),
+            "rmse": metrics.get("train_rmse"),
+            "mae": metrics.get("train_mae"),
+            "pearson_r": metrics.get("train_pearson_r", 0.0),
+        },
+    }
+    artifacts = {
+        "verified_discovery_artifact_dir": verified_discovery_dir,
+        "verified_discovery_top_n": top_n,
+        "multi_model_results": [
+            {
+                "name": "Verified discovery model",
+                "agent_id": result["agent_id"],
+                "r2": result["metrics"]["r2"],
+                "rmse": result["metrics"]["rmse"],
+                "mae": result["metrics"]["mae"],
+                "pearson_r": result["metrics"]["pearson_r"],
+                "n_samples": result["n_samples"],
+                "n_features": result["n_features"],
+            }
+        ],
+    }
+    return {"results": [result], "artifacts": artifacts}
+
+
+def _package_manifest(
+    *,
+    dataset_id: str,
+    output_root: Path,
+    evidence_mode: str,
+    discovery_artifacts,
+    candidate_library_dir: Path | None,
+    candidate_library_rows: int | None,
+    report_dir: Path,
+    report_quality_score: float,
+    root_manifest_path: Path,
+    package_manifest_path: Path,
+) -> dict[str, Any]:
+    return {
+        "dataset_id": dataset_id,
+        "generated_at": _now_iso(),
+        "package_runner": "run_research_package",
+        "evidence_mode": evidence_mode,
+        "publication_grade": evidence_mode == "external-cached",
+        "verified_rows": discovery_artifacts.verified_rows,
+        "quarantine_rows": discovery_artifacts.quarantine_rows,
+        "ranked_candidates": discovery_artifacts.ranked_candidates,
+        "candidate_library_rows": candidate_library_rows,
+        "report_quality_score": report_quality_score,
+        "outputs": {
+            "verified_discovery_dir": _relative(discovery_artifacts.output_dir, output_root),
+            "candidate_library_dir": _relative(candidate_library_dir, output_root) if candidate_library_dir else None,
+            "report_dir": _relative(report_dir, output_root),
+            "main_text_report_md": _relative(report_dir / "main_text" / "main_text_report.md", output_root),
+            "supporting_information_md": _relative(report_dir / "si" / "supporting_information.md", output_root),
+            "root_provenance_manifest_json": _relative(root_manifest_path, output_root),
+            "package_manifest_json": _relative(package_manifest_path, output_root),
+        },
+    }
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_json(payload: dict[str, Any], path: Path) -> None:
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _relative(path: Path | None, root: Path) -> str | None:
+    if path is None:
+        return None
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, help="CSV/XLSX PSC source table.")
+    parser.add_argument("--output-dir", required=True, help="Directory for the complete research package.")
+    parser.add_argument("--dataset-id", required=True, help="Stable package dataset/run identifier.")
+    parser.add_argument("--evidence-mode", choices=("external-cached", "source-columns"), default="external-cached")
+    parser.add_argument("--candidate-source", help="Optional CSV/XLSX source table for external candidates.")
+    parser.add_argument("--candidate-source-name", help="Source name for candidate-source normalization.")
+    parser.add_argument("--cache-dir", help="External evidence cache directory.")
+    parser.add_argument("--max-rows", type=int, help="Optional row cap for smoke runs.")
+    parser.add_argument("--min-verified-rows", type=int, default=10)
+    parser.add_argument("--top-k", type=int, default=100)
+    parser.add_argument("--report-quality-target", choices=("standard", "top-journal"), default="top-journal")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    artifacts = run_research_package(
+        input_path=args.input,
+        output_dir=args.output_dir,
+        dataset_id=args.dataset_id,
+        evidence_mode=args.evidence_mode,
+        candidate_source_path=args.candidate_source,
+        candidate_source_name=args.candidate_source_name,
+        cache_dir=args.cache_dir,
+        max_rows=args.max_rows,
+        min_verified_rows=args.min_verified_rows,
+        top_k=args.top_k,
+        report_quality_target=args.report_quality_target,
+    )
+    print(f"[research-package] package_manifest={artifacts.package_manifest_json}")
+    print(f"[research-package] root_provenance_manifest={artifacts.root_provenance_manifest_json}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hybrid_agent_exploration/src/run_research_package.py
+++ b/hybrid_agent_exploration/src/run_research_package.py
@@ -75,9 +75,10 @@ def run_research_package(
         candidate_pool = candidate_artifacts.candidate_library_csv
         candidate_library_rows = candidate_artifacts.output_count
 
+    verification_level = _verification_level(evidence_mode)
     run_metadata = {
         "evidence_mode": evidence_mode,
-        "verification_level": "external_cached" if evidence_mode == "external-cached" else "source_columns_only",
+        "verification_level": verification_level,
         "publication_grade": evidence_mode == "external-cached",
         "source_columns_is_smoke_only": evidence_mode == "source-columns",
         "input_path": str(Path(input_path)),
@@ -105,6 +106,16 @@ def run_research_package(
     report_inputs = _report_inputs(
         verified_discovery_dir,
         top_n=verified_discovery_top_n or top_k,
+        evidence_context={
+            "evidence_mode": evidence_mode,
+            "verification_level": verification_level,
+            "publication_grade": evidence_mode == "external-cached",
+            "source_columns_is_smoke_only": evidence_mode == "source-columns",
+            "max_rows": max_rows,
+            "max_rows_is_smoke_only": max_rows is not None,
+            "metric_scope": "training_only",
+            "candidate_pool_contract_version": CANDIDATE_LIBRARY_CONTRACT_VERSION,
+        },
     )
     main_bundle = TopJournalReport(
         report_inputs["results"],
@@ -140,6 +151,8 @@ def run_research_package(
             report_quality_score=main_bundle.quality_score,
             root_manifest_path=root_manifest_path,
             package_manifest_path=package_manifest_path,
+            max_rows=max_rows,
+            candidate_pool_contract_version=CANDIDATE_LIBRARY_CONTRACT_VERSION,
         ),
         package_manifest_path,
     )
@@ -153,7 +166,12 @@ def run_research_package(
     )
 
 
-def _report_inputs(verified_discovery_dir: Path, *, top_n: int) -> dict[str, Any]:
+def _report_inputs(
+    verified_discovery_dir: Path,
+    *,
+    top_n: int,
+    evidence_context: dict[str, Any],
+) -> dict[str, Any]:
     metrics = _read_json(verified_discovery_dir / "model" / "model_metrics.json")
     workflow = _read_json(verified_discovery_dir / "workflow_manifest.json")
     feature_columns = metrics.get("feature_columns", [])
@@ -167,7 +185,7 @@ def _report_inputs(verified_discovery_dir: Path, *, top_n: int) -> dict[str, Any
             "layer1": {"method_id": "strict_verified_data"},
             "layer2": {"method_id": "default_smiles_features"},
             "layer3": {"method_id": metrics.get("model_class", "model")},
-            "layer4": {"method_id": "verified_discovery_training"},
+            "layer4": {"method_id": "training_only_fit"},
             "layer5": {"method_id": "candidate_discovery_report"},
             "target": metrics.get("target_column", "delta_pce"),
             "baseline_as_feature": False,
@@ -177,12 +195,14 @@ def _report_inputs(verified_discovery_dir: Path, *, top_n: int) -> dict[str, Any
             "r2": metrics.get("train_r2", 0.0),
             "rmse": metrics.get("train_rmse"),
             "mae": metrics.get("train_mae"),
-            "pearson_r": metrics.get("train_pearson_r", 0.0),
+            "pearson_r": metrics.get("train_pearson_r"),
+            "metric_scope": "training_only",
         },
     }
     artifacts = {
         "verified_discovery_artifact_dir": verified_discovery_dir,
         "verified_discovery_top_n": top_n,
+        "evidence_context": evidence_context,
         "multi_model_results": [
             {
                 "name": "Verified discovery model",
@@ -211,13 +231,21 @@ def _package_manifest(
     report_quality_score: float,
     root_manifest_path: Path,
     package_manifest_path: Path,
+    max_rows: int | None,
+    candidate_pool_contract_version: str,
 ) -> dict[str, Any]:
+    verification_level = _verification_level(evidence_mode)
     return {
         "dataset_id": dataset_id,
         "generated_at": _now_iso(),
         "package_runner": "run_research_package",
         "evidence_mode": evidence_mode,
+        "verification_level": verification_level,
         "publication_grade": evidence_mode == "external-cached",
+        "source_columns_is_smoke_only": evidence_mode == "source-columns",
+        "max_rows": max_rows,
+        "max_rows_is_smoke_only": max_rows is not None,
+        "candidate_pool_contract_version": candidate_pool_contract_version,
         "verified_rows": discovery_artifacts.verified_rows,
         "quarantine_rows": discovery_artifacts.quarantine_rows,
         "ranked_candidates": discovery_artifacts.ranked_candidates,
@@ -254,6 +282,10 @@ def _relative(path: Path | None, root: Path) -> str | None:
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _verification_level(evidence_mode: str) -> str:
+    return "external_cached" if evidence_mode == "external-cached" else "source_columns_only"
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:

--- a/tests/test_research_package_runner.py
+++ b/tests/test_research_package_runner.py
@@ -82,14 +82,21 @@ def test_research_package_runner_generates_all_scientific_artifacts(tmp_path):
         package.verified_discovery_dir / "dataset" / "verified_train.csv",
         package.verified_discovery_dir / "dataset" / "quarantine.csv",
         package.verified_discovery_dir / "dataset" / "doi_manifest.json",
+        package.verified_discovery_dir / "dataset" / "provenance.json",
         package.verified_discovery_dir / "dataset" / "data_audit_report.md",
+        package.verified_discovery_dir / "model" / "model_metrics.json",
+        package.verified_discovery_dir / "model" / "model_manifest.json",
         package.verified_discovery_dir / "discovery" / "ranked_candidates.csv",
+        package.verified_discovery_dir / "discovery" / "candidate_discovery_manifest.json",
+        package.verified_discovery_dir / "discovery" / "candidate_discovery_audit.md",
         package.verified_discovery_dir / "workflow_manifest.json",
         package.candidate_library_dir / "candidate_library.csv",
         package.candidate_library_dir / "source_summary.json",
         package.candidate_library_dir / "provenance.json",
         package.report_dir / "main_text" / "main_text_report.md",
         package.report_dir / "main_text" / "claim_ledger.json",
+        package.report_dir / "main_text" / "review_report.json",
+        package.report_dir / "main_text" / "run_manifest.json",
         package.report_dir / "si" / "supporting_information.md",
         package.root_provenance_manifest_json,
         package.package_manifest_json,
@@ -103,7 +110,57 @@ def test_research_package_runner_generates_all_scientific_artifacts(tmp_path):
     assert package_manifest["candidate_library_rows"] == 1
     assert package_manifest["ranked_candidates"] == 1
     assert package_manifest["publication_grade"] is False
+    assert package_manifest["verification_level"] == "source_columns_only"
+    assert package_manifest["source_columns_is_smoke_only"] is True
+    assert package_manifest["max_rows"] is None
+    assert package_manifest["max_rows_is_smoke_only"] is False
+    assert package_manifest["candidate_pool_contract_version"] == "candidate-library-v1"
     assert package_manifest["outputs"]["root_provenance_manifest_json"] == "provenance_manifest.json"
+
+    workflow_manifest = json.loads(
+        (package.verified_discovery_dir / "workflow_manifest.json").read_text(encoding="utf-8")
+    )
+    assert workflow_manifest["publication_grade"] is False
+    assert workflow_manifest["verification_level"] == "source_columns_only"
+    assert workflow_manifest["source_columns_is_smoke_only"] is True
+
+    candidate_provenance = json.loads(
+        (package.candidate_library_dir / "provenance.json").read_text(encoding="utf-8")
+    )
+    assert candidate_provenance["network_access"] == "not_used"
+    assert candidate_provenance["does_not_generate_candidates"] is True
+    assert candidate_provenance["validation"]["status"] == "passed"
+
+    report_text = (package.report_dir / "main_text" / "main_text_report.md").read_text(encoding="utf-8")
+    assert "training-only" in report_text
+    unsupported_phrases = [
+        "substructural fingerprints (Morgan) outperform",
+        "incorporating baseline device PCE as a feature helps",
+        "SHAP interpretability analysis suggests",
+        "SHAP analysis reveals",
+        "excellent predictive ability",
+        "external validation was performed",
+    ]
+    for phrase in unsupported_phrases:
+        assert phrase not in report_text
+
+    review_report = json.loads(
+        (package.report_dir / "main_text" / "review_report.json").read_text(encoding="utf-8")
+    )
+    assert review_report["claim_audit"]["unsupported_claims"] == []
+
+    run_manifest = json.loads(
+        (package.report_dir / "main_text" / "run_manifest.json").read_text(encoding="utf-8")
+    )
+    assert run_manifest["best_model"]["pearson_r"] is None
+    assert run_manifest["evidence_context"]["source_columns_is_smoke_only"] is True
+    assert run_manifest["evidence_context"]["metric_scope"] == "training_only"
+
+    si_text = (package.report_dir / "si" / "supporting_information.md").read_text(encoding="utf-8")
+    assert "source-columns" in si_text
+    assert "smoke-only" in si_text
+    assert "training-only" in si_text
+    assert "Cross-validation was not supplied" in si_text
 
     root_manifest = json.loads(package.root_provenance_manifest_json.read_text(encoding="utf-8"))
     assert root_manifest["dataset_id"] == "package-fixture"
@@ -116,4 +173,3 @@ def test_research_package_runner_generates_all_scientific_artifacts(tmp_path):
     ranked = pd.read_csv(package.verified_discovery_dir / "discovery" / "ranked_candidates.csv")
     assert ranked["candidate_id"].tolist() == ["fixture-vendor-source:pubchem-7843"]
     assert "candidate_score" in ranked.columns
-

--- a/tests/test_research_package_runner.py
+++ b/tests/test_research_package_runner.py
@@ -1,0 +1,119 @@
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1] / "hybrid_agent_exploration"
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+
+def _raw_record(record_id: str, doi: str, smiles: str, delta: float, *, title: str = "Verified PSC additive paper") -> dict:
+    return {
+        "record_id": record_id,
+        "doi": doi,
+        "title": title,
+        "year": 2026,
+        "journal": "Journal of Physical Chemistry Letters",
+        "smiles": smiles,
+        "pubchem_id": str(700 + int(record_id.split("-")[-1])),
+        "cas_number": f"64-17-{record_id[-1]}",
+        "jv_reverse_scan_pce_without_modulator": 18.0,
+        "jv_reverse_scan_pce": 18.0 + delta,
+        "delta_pce": delta,
+    }
+
+
+def _candidate_source() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "smiles": "CCCC",
+                "pubchem_id": "7843",
+                "cas": "106-97-8",
+                "vendor": "TCI",
+                "vendor_catalog_id": "B0001",
+                "source_url": "https://pubchem.ncbi.nlm.nih.gov/compound/7843",
+                "availability": "commercial",
+                "synthesis": "commercial",
+                "safety": "sds_available",
+                "verification_sources": json.dumps(
+                    [
+                        {"kind": "molecule", "source": "pubchem", "pubchem_id": "7843"},
+                        {"kind": "availability", "source": "vendor_catalog", "vendor_name": "TCI"},
+                    ]
+                ),
+            }
+        ]
+    )
+
+
+def test_research_package_runner_generates_all_scientific_artifacts(tmp_path):
+    from run_research_package import run_research_package
+
+    raw_csv = tmp_path / "raw_psc.csv"
+    candidate_csv = tmp_path / "candidate_source.csv"
+    output_dir = tmp_path / "research_package"
+    pd.DataFrame(
+        [
+            _raw_record("row-001", "10.1021/acs.jpclett.6c00119", "C", 0.25),
+            _raw_record("row-002", "10.1021/acs.jpclett.6c00120", "CC", 0.50),
+            _raw_record("row-003", "10.1021/acs.jpclett.6c00121", "CCC", 0.75),
+            _raw_record("row-004", "10.1021/acs.jpclett.6c00122", "CCCC", 1.00),
+            _raw_record("row-005", "", "CCO", 0.40, title="Missing DOI row"),
+        ]
+    ).to_csv(raw_csv, index=False)
+    _candidate_source().to_csv(candidate_csv, index=False)
+
+    package = run_research_package(
+        input_path=raw_csv,
+        output_dir=output_dir,
+        dataset_id="package-fixture",
+        evidence_mode="source-columns",
+        candidate_source_path=candidate_csv,
+        candidate_source_name="fixture-vendor-source",
+        min_verified_rows=4,
+        top_k=1,
+        report_quality_target="top-journal",
+    )
+
+    required_paths = [
+        package.verified_discovery_dir / "dataset" / "verified_train.csv",
+        package.verified_discovery_dir / "dataset" / "quarantine.csv",
+        package.verified_discovery_dir / "dataset" / "doi_manifest.json",
+        package.verified_discovery_dir / "dataset" / "data_audit_report.md",
+        package.verified_discovery_dir / "discovery" / "ranked_candidates.csv",
+        package.verified_discovery_dir / "workflow_manifest.json",
+        package.candidate_library_dir / "candidate_library.csv",
+        package.candidate_library_dir / "source_summary.json",
+        package.candidate_library_dir / "provenance.json",
+        package.report_dir / "main_text" / "main_text_report.md",
+        package.report_dir / "main_text" / "claim_ledger.json",
+        package.report_dir / "si" / "supporting_information.md",
+        package.root_provenance_manifest_json,
+        package.package_manifest_json,
+    ]
+    assert all(path.exists() for path in required_paths)
+
+    package_manifest = json.loads(package.package_manifest_json.read_text(encoding="utf-8"))
+    assert package_manifest["dataset_id"] == "package-fixture"
+    assert package_manifest["verified_rows"] == 4
+    assert package_manifest["quarantine_rows"] == 1
+    assert package_manifest["candidate_library_rows"] == 1
+    assert package_manifest["ranked_candidates"] == 1
+    assert package_manifest["publication_grade"] is False
+    assert package_manifest["outputs"]["root_provenance_manifest_json"] == "provenance_manifest.json"
+
+    root_manifest = json.loads(package.root_provenance_manifest_json.read_text(encoding="utf-8"))
+    assert root_manifest["dataset_id"] == "package-fixture"
+    assert root_manifest["strict_verified_training_only"] is True
+    assert root_manifest["verified_candidate_discovery_only"] is True
+    assert "candidate_library:candidate_library_csv" in {
+        item["id"] for item in root_manifest["artifacts"]["discovery"]
+    }
+
+    ranked = pd.read_csv(package.verified_discovery_dir / "discovery" / "ranked_candidates.csv")
+    assert ranked["candidate_id"].tolist() == ["fixture-vendor-source:pubchem-7843"]
+    assert "candidate_score" in ranked.columns
+


### PR DESCRIPTION
## Summary
- add run_research_package.py to orchestrate verified discovery, optional external candidate-library normalization, main report, SI, root provenance, and package manifest generation
- add a package-level manifest with verified/quarantine/candidate/ranked counts and output paths
- add an end-to-end test proving the runner generates training data, quarantine data, DOI manifest, candidate library, audit report, report/SI, root provenance manifest, and package manifest

## Validation
- RED: PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_research_package_runner.py -> ModuleNotFoundError before implementation
- GREEN: PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_research_package_runner.py -> 1 passed
- Regression: PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_research_package_runner.py tests/test_run_verified_discovery_cli.py tests/test_candidate_library_builder.py tests/test_root_provenance_manifest.py -> 9 passed
- Compile: python -m py_compile hybrid_agent_exploration/src/run_research_package.py
- Real source-columns smoke: generated package at hybrid_agent_exploration/results/verified_discovery_smoke_package/package with verified_rows=30, quarantine_rows=470, candidate_library_rows=8, ranked_candidates=8, report_quality_score=1.0, publication_grade=false