### PR TITLE
fix: accept current PubChem SMILES fields

### DIFF
--- a/hybrid_agent_exploration/src/harness/authenticity.py
+++ b/hybrid_agent_exploration/src/harness/authenticity.py
@@ -453,7 +453,7 @@ class PubChemMoleculeVerifier:
         props = response.json().get("PropertyTable", {}).get("Properties", [])
         if not props:
             return None
-        smiles = props[0].get("CanonicalSMILES")
+        smiles = _pubchem_smiles(props[0])
         if not smiles:
             return None
         return MoleculeEvidence(
@@ -463,6 +463,14 @@ class PubChemMoleculeVerifier:
             source="pubchem",
             url=f"https://pubchem.ncbi.nlm.nih.gov/compound/{cid}",
         )
+
+
+def _pubchem_smiles(properties: dict[str, Any]) -> str:
+    for key in ("CanonicalSMILES", "SMILES", "ConnectivitySMILES", "IsomericSMILES"):
+        smiles = _clean_text(properties.get(key))
+        if smiles:
+            return smiles
+    return ""
 
 
 def _crossref_year(message: dict[str, Any]) -> int | None:

--- a/tests/test_evidence_cache_verifiers.py
+++ b/tests/test_evidence_cache_verifiers.py
@@ -46,6 +46,38 @@ def test_pubchem_verifier_normalizes_excel_float_cid(monkeypatch):
     ]
 
 
+def test_pubchem_verifier_accepts_current_smiles_payloads(monkeypatch):
+    from harness import authenticity
+    from harness.authenticity import PubChemMoleculeVerifier
+
+    def make_get(prop_key):
+        class Response:
+            status_code = 200
+
+            def json(self):
+                return {
+                    "PropertyTable": {
+                        "Properties": [
+                            {"CID": 7843, prop_key: "CCCC"},
+                        ]
+                    }
+                }
+
+        return lambda url, timeout: Response()
+
+    for prop_key in ("SMILES", "ConnectivitySMILES"):
+        monkeypatch.setattr(authenticity.requests, "get", make_get(prop_key))
+
+        evidence = PubChemMoleculeVerifier(timeout=3)({
+            "pubchem_id": "7843",
+            "cas_number": "106-97-8",
+        })
+
+        assert evidence is not None
+        assert evidence.smiles == "CCCC"
+        assert evidence.pubchem_id == "7843"
+
+
 def test_cached_reference_verifier_deduplicates_and_persists(tmp_path):
     from harness.authenticity import CachedReferenceVerifier, ReferenceEvidence
 


### PR DESCRIPTION
## Summary
- Accept current PubChem PUG REST molecule payload fields: SMILES and ConnectivitySMILES, in addition to CanonicalSMILES.
- Add a regression test for the schema drift that caused live CID evidence to return None.

## Verification
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_evidence_cache_verifiers.py tests/test_real_data_authenticity.py tests/test_verified_dataset_builder.py tests/test_run_verified_discovery_cli.py -> 17 passed
- Live PubChem verifier smoke: CID 7843 returned CCCC; CID 104810.0 returned [Ba+2]
- python -m py_compile hybrid_agent_exploration/src/harness/authenticity.py
- git diff --check