### PR TITLE
feat: strengthen research package provenance

### DIFF
--- a/hybrid_agent_exploration/src/reporting/root_provenance_manifest.py
+++ b/hybrid_agent_exploration/src/reporting/root_provenance_manifest.py
@@ -29,6 +29,8 @@ def generate_root_provenance_manifest(
     *,
     candidate_library_dir: str | Path | None = None,
     package_manifest_path: str | Path | None = None,
+    input_path: str | Path | None = None,
+    candidate_source_path: str | Path | None = None,
     output_path: str | Path | None = None,
 ) -> dict[str, Any]:
     """Build and write a root-level provenance manifest.
@@ -41,6 +43,9 @@ def generate_root_provenance_manifest(
             source_summary.json, and provenance.json from CandidateLibraryBuilder.
         package_manifest_path: Optional top-level package_manifest.json emitted by
             run_research_package.
+        input_path: Optional original PSC source table used by the package.
+        candidate_source_path: Optional original candidate-source table used by
+            CandidateLibraryBuilder.
         output_path: Optional explicit path. Defaults to the common parent of
             report_dir and si_dir plus ``provenance_manifest.json``.
 
@@ -53,6 +58,8 @@ def generate_root_provenance_manifest(
     si_root = Path(si_dir)
     candidate_root = Path(candidate_library_dir) if candidate_library_dir is not None else None
     package_manifest = Path(package_manifest_path) if package_manifest_path is not None else None
+    source_input = Path(input_path) if input_path is not None else None
+    candidate_source = Path(candidate_source_path) if candidate_source_path is not None else None
     output = Path(output_path) if output_path is not None else _default_output_path(report_root, si_root)
     root_dir = output.parent
 
@@ -135,6 +142,10 @@ def generate_root_provenance_manifest(
             "digest": "first_16_hex_chars",
             "max_bytes_hashed_per_file": HASH_BYTES_LIMIT,
         },
+        "source_input_hash_policy": {
+            "algorithm": "sha256",
+            "digest": "full_hex",
+        },
         "roots": {
             "verified_discovery_artifact_dir": _display_path(discovery_root, root_dir),
             "report_dir": _display_path(report_root, root_dir),
@@ -142,6 +153,10 @@ def generate_root_provenance_manifest(
         },
         "source_manifests": {
             "workflow_manifest_json": _file_facts(workflow_manifest_path, root_dir=root_dir),
+        },
+        "source_inputs": {
+            "input_table": _full_file_facts(source_input, root_dir=root_dir) if source_input is not None else None,
+            "candidate_source_table": _full_file_facts(candidate_source, root_dir=root_dir) if candidate_source is not None else None,
         },
         "artifacts": {category: sorted(records, key=lambda item: item["id"]) for category, records in artifacts.items()},
     }
@@ -164,6 +179,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--si-dir", required=True)
     parser.add_argument("--candidate-library-dir")
     parser.add_argument("--package-manifest-path")
+    parser.add_argument("--input-path")
+    parser.add_argument("--candidate-source-path")
     parser.add_argument("--output-path")
     args = parser.parse_args(argv)
     manifest = generate_root_provenance_manifest(
@@ -172,6 +189,8 @@ def main(argv: list[str] | None = None) -> int:
         args.si_dir,
         candidate_library_dir=args.candidate_library_dir,
         package_manifest_path=args.package_manifest_path,
+        input_path=args.input_path,
+        candidate_source_path=args.candidate_source_path,
         output_path=args.output_path,
     )
     output_path = args.output_path or _default_output_path(Path(args.report_dir), Path(args.si_dir))
@@ -251,11 +270,29 @@ def _file_facts(path: Path, *, root_dir: Path) -> dict[str, Any]:
     }
 
 
+def _full_file_facts(path: Path, *, root_dir: Path) -> dict[str, Any]:
+    exists = path.exists()
+    return {
+        "path": _display_path(path, root_dir),
+        "exists": exists,
+        "size_bytes": path.stat().st_size if exists and path.is_file() else None,
+        "sha256": _sha256(path) if exists and path.is_file() else None,
+    }
+
+
 def _sha256_16(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as handle:
         digest.update(handle.read(HASH_BYTES_LIMIT))
     return digest.hexdigest()[:16]
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 def _resolve_artifact_path(root: Path, value: str) -> Path:

--- a/hybrid_agent_exploration/src/reporting/root_provenance_manifest.py
+++ b/hybrid_agent_exploration/src/reporting/root_provenance_manifest.py
@@ -19,7 +19,7 @@ from typing import Any
 MANIFEST_NAME = "provenance_manifest.json"
 SCHEMA_VERSION = "root-provenance-manifest-v1"
 HASH_BYTES_LIMIT = 1024 * 1024
-ARTIFACT_CATEGORIES = ("dataset", "model", "discovery", "report", "SI", "claim", "review", "audit")
+ARTIFACT_CATEGORIES = ("dataset", "model", "discovery", "report", "SI", "claim", "review", "audit", "package")
 
 
 def generate_root_provenance_manifest(
@@ -28,6 +28,7 @@ def generate_root_provenance_manifest(
     si_dir: str | Path,
     *,
     candidate_library_dir: str | Path | None = None,
+    package_manifest_path: str | Path | None = None,
     output_path: str | Path | None = None,
 ) -> dict[str, Any]:
     """Build and write a root-level provenance manifest.
@@ -38,6 +39,8 @@ def generate_root_provenance_manifest(
         si_dir: Directory containing supplementary information artifacts.
         candidate_library_dir: Optional directory containing candidate_library.csv,
             source_summary.json, and provenance.json from CandidateLibraryBuilder.
+        package_manifest_path: Optional top-level package_manifest.json emitted by
+            run_research_package.
         output_path: Optional explicit path. Defaults to the common parent of
             report_dir and si_dir plus ``provenance_manifest.json``.
 
@@ -49,6 +52,7 @@ def generate_root_provenance_manifest(
     report_root = Path(report_dir)
     si_root = Path(si_dir)
     candidate_root = Path(candidate_library_dir) if candidate_library_dir is not None else None
+    package_manifest = Path(package_manifest_path) if package_manifest_path is not None else None
     output = Path(output_path) if output_path is not None else _default_output_path(report_root, si_root)
     root_dir = output.parent
 
@@ -108,6 +112,17 @@ def generate_root_provenance_manifest(
                 )
             )
 
+    if package_manifest is not None:
+        artifacts["package"].append(
+            _artifact_record(
+                "package_manifest_json",
+                package_manifest,
+                root_dir=root_dir,
+                source_root=package_manifest.parent,
+                declared_in="package_manifest_path",
+            )
+        )
+
     manifest = {
         "schema_version": SCHEMA_VERSION,
         "generated_at": _now_iso(),
@@ -132,6 +147,8 @@ def generate_root_provenance_manifest(
     }
     if candidate_root is not None:
         manifest["roots"]["candidate_library_dir"] = _display_path(candidate_root, root_dir)
+    if package_manifest is not None:
+        manifest["source_manifests"]["package_manifest_json"] = _file_facts(package_manifest, root_dir=root_dir)
 
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
@@ -146,6 +163,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--report-dir", required=True)
     parser.add_argument("--si-dir", required=True)
     parser.add_argument("--candidate-library-dir")
+    parser.add_argument("--package-manifest-path")
     parser.add_argument("--output-path")
     args = parser.parse_args(argv)
     manifest = generate_root_provenance_manifest(
@@ -153,6 +171,7 @@ def main(argv: list[str] | None = None) -> int:
         args.report_dir,
         args.si_dir,
         candidate_library_dir=args.candidate_library_dir,
+        package_manifest_path=args.package_manifest_path,
         output_path=args.output_path,
     )
     output_path = args.output_path or _default_output_path(Path(args.report_dir), Path(args.si_dir))

--- a/hybrid_agent_exploration/src/run_research_package.py
+++ b/hybrid_agent_exploration/src/run_research_package.py
@@ -25,7 +25,10 @@ from screening.verified_discovery_workflow import VerifiedDiscoveryWorkflow
 
 
 PACKAGE_MANIFEST_SCHEMA_VERSION = "research-package-manifest-v1"
-FILE_HASH_BYTES_LIMIT = 1024 * 1024
+INPUT_HASH_POLICY = {
+    "algorithm": "sha256",
+    "digest": "full_hex",
+}
 
 
 @dataclass(frozen=True)
@@ -167,6 +170,8 @@ def run_research_package(
         si_path.parent,
         candidate_library_dir=candidate_library_dir,
         package_manifest_path=package_manifest_path,
+        input_path=input_path,
+        candidate_source_path=candidate_source_path,
         output_path=root_manifest_path,
     )
     return ResearchPackageArtifacts(
@@ -256,6 +261,24 @@ def _package_manifest(
     candidate_pool_contract_version: str,
 ) -> dict[str, Any]:
     verification_level = _verification_level(evidence_mode)
+    runner_args = {
+        "input": str(input_path),
+        "output_dir": str(output_root),
+        "dataset_id": dataset_id,
+        "evidence_mode": evidence_mode,
+        "candidate_source": str(candidate_source_path) if candidate_source_path is not None else None,
+        "candidate_source_name": candidate_source_name,
+        "cache_dir": str(cache_dir) if cache_dir is not None else None,
+        "max_rows": max_rows,
+        "min_verified_rows": min_verified_rows,
+        "top_k": top_k,
+        "report_quality_target": report_quality_target,
+        "verified_discovery_top_n": verified_discovery_top_n,
+    }
+    source_table_facts = _file_facts(input_path)
+    candidate_source_facts = _file_facts(candidate_source_path) if candidate_source_path else None
+    if candidate_source_facts is not None:
+        candidate_source_facts["source_name"] = candidate_source_name
     return {
         "schema_version": PACKAGE_MANIFEST_SCHEMA_VERSION,
         "dataset_id": dataset_id,
@@ -263,29 +286,13 @@ def _package_manifest(
         "package_runner": "run_research_package",
         "runner": {
             "name": "run_research_package",
-            "args": {
-                "input": str(input_path),
-                "output_dir": str(output_root),
-                "dataset_id": dataset_id,
-                "evidence_mode": evidence_mode,
-                "candidate_source": str(candidate_source_path) if candidate_source_path is not None else None,
-                "candidate_source_name": candidate_source_name,
-                "cache_dir": str(cache_dir) if cache_dir is not None else None,
-                "max_rows": max_rows,
-                "min_verified_rows": min_verified_rows,
-                "top_k": top_k,
-                "report_quality_target": report_quality_target,
-                "verified_discovery_top_n": verified_discovery_top_n,
-            },
+            "args": runner_args,
         },
-        "input_hash_policy": {
-            "algorithm": "sha256",
-            "digest": "first_16_hex_chars",
-            "max_bytes_hashed_per_file": FILE_HASH_BYTES_LIMIT,
-        },
+        "runner_args": runner_args,
+        "input_hash_policy": INPUT_HASH_POLICY,
         "inputs": {
-            "source_table": _file_facts(input_path),
-            "candidate_source": _file_facts(candidate_source_path) if candidate_source_path else None,
+            "source_table": source_table_facts,
+            "candidate_source": candidate_source_facts,
         },
         "evidence_mode": evidence_mode,
         "verification_level": verification_level,
@@ -325,15 +332,16 @@ def _file_facts(path: Path) -> dict[str, Any]:
         "path": str(path),
         "exists": exists,
         "size_bytes": path.stat().st_size if exists and path.is_file() else None,
-        "sha256_16": _sha256_16(path) if exists and path.is_file() else None,
+        "sha256": _sha256(path) if exists and path.is_file() else None,
     }
 
 
-def _sha256_16(path: Path) -> str:
+def _sha256(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as handle:
-        digest.update(handle.read(FILE_HASH_BYTES_LIMIT))
-    return digest.hexdigest()[:16]
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 def _relative(path: Path | None, root: Path) -> str | None:

--- a/hybrid_agent_exploration/src/run_research_package.py
+++ b/hybrid_agent_exploration/src/run_research_package.py
@@ -8,6 +8,7 @@ manifest into one reproducible artifact directory.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -21,6 +22,10 @@ from run_verified_discovery import build_authenticator, default_cache_dir, load_
 from screening.candidate_library_builder import CandidateLibraryBuilder
 from screening.verified_candidate_discovery import CANDIDATE_LIBRARY_CONTRACT_VERSION
 from screening.verified_discovery_workflow import VerifiedDiscoveryWorkflow
+
+
+PACKAGE_MANIFEST_SCHEMA_VERSION = "research-package-manifest-v1"
+FILE_HASH_BYTES_LIMIT = 1024 * 1024
 
 
 @dataclass(frozen=True)
@@ -130,20 +135,20 @@ def run_research_package(
     ).generate()
 
     root_manifest_path = output_root / "provenance_manifest.json"
-    generate_root_provenance_manifest(
-        verified_discovery_dir,
-        main_bundle.path.parent,
-        si_path.parent,
-        candidate_library_dir=candidate_library_dir,
-        output_path=root_manifest_path,
-    )
-
     package_manifest_path = output_root / "package_manifest.json"
     _write_json(
         _package_manifest(
             dataset_id=dataset_id,
             output_root=output_root,
             evidence_mode=evidence_mode,
+            input_path=Path(input_path),
+            candidate_source_path=Path(candidate_source_path) if candidate_source_path is not None else None,
+            candidate_source_name=candidate_source_name,
+            cache_dir=cache_root if evidence_mode == "external-cached" else None,
+            min_verified_rows=min_verified_rows,
+            top_k=top_k,
+            report_quality_target=report_quality_target,
+            verified_discovery_top_n=verified_discovery_top_n,
             discovery_artifacts=discovery_artifacts,
             candidate_library_dir=candidate_library_dir,
             candidate_library_rows=candidate_library_rows,
@@ -155,6 +160,14 @@ def run_research_package(
             candidate_pool_contract_version=CANDIDATE_LIBRARY_CONTRACT_VERSION,
         ),
         package_manifest_path,
+    )
+    generate_root_provenance_manifest(
+        verified_discovery_dir,
+        main_bundle.path.parent,
+        si_path.parent,
+        candidate_library_dir=candidate_library_dir,
+        package_manifest_path=package_manifest_path,
+        output_path=root_manifest_path,
     )
     return ResearchPackageArtifacts(
         output_dir=output_root,
@@ -224,6 +237,14 @@ def _package_manifest(
     dataset_id: str,
     output_root: Path,
     evidence_mode: str,
+    input_path: Path,
+    candidate_source_path: Path | None,
+    candidate_source_name: str | None,
+    cache_dir: Path | None,
+    min_verified_rows: int,
+    top_k: int,
+    report_quality_target: str,
+    verified_discovery_top_n: int | None,
     discovery_artifacts,
     candidate_library_dir: Path | None,
     candidate_library_rows: int | None,
@@ -236,9 +257,36 @@ def _package_manifest(
 ) -> dict[str, Any]:
     verification_level = _verification_level(evidence_mode)
     return {
+        "schema_version": PACKAGE_MANIFEST_SCHEMA_VERSION,
         "dataset_id": dataset_id,
         "generated_at": _now_iso(),
         "package_runner": "run_research_package",
+        "runner": {
+            "name": "run_research_package",
+            "args": {
+                "input": str(input_path),
+                "output_dir": str(output_root),
+                "dataset_id": dataset_id,
+                "evidence_mode": evidence_mode,
+                "candidate_source": str(candidate_source_path) if candidate_source_path is not None else None,
+                "candidate_source_name": candidate_source_name,
+                "cache_dir": str(cache_dir) if cache_dir is not None else None,
+                "max_rows": max_rows,
+                "min_verified_rows": min_verified_rows,
+                "top_k": top_k,
+                "report_quality_target": report_quality_target,
+                "verified_discovery_top_n": verified_discovery_top_n,
+            },
+        },
+        "input_hash_policy": {
+            "algorithm": "sha256",
+            "digest": "first_16_hex_chars",
+            "max_bytes_hashed_per_file": FILE_HASH_BYTES_LIMIT,
+        },
+        "inputs": {
+            "source_table": _file_facts(input_path),
+            "candidate_source": _file_facts(candidate_source_path) if candidate_source_path else None,
+        },
         "evidence_mode": evidence_mode,
         "verification_level": verification_level,
         "publication_grade": evidence_mode == "external-cached",
@@ -269,6 +317,23 @@ def _read_json(path: Path) -> dict[str, Any]:
 
 def _write_json(payload: dict[str, Any], path: Path) -> None:
     path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _file_facts(path: Path) -> dict[str, Any]:
+    exists = path.exists()
+    return {
+        "path": str(path),
+        "exists": exists,
+        "size_bytes": path.stat().st_size if exists and path.is_file() else None,
+        "sha256_16": _sha256_16(path) if exists and path.is_file() else None,
+    }
+
+
+def _sha256_16(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        digest.update(handle.read(FILE_HASH_BYTES_LIMIT))
+    return digest.hexdigest()[:16]
 
 
 def _relative(path: Path | None, root: Path) -> str | None:

--- a/hybrid_agent_exploration/src/screening/candidate_library_builder.py
+++ b/hybrid_agent_exploration/src/screening/candidate_library_builder.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import re
+import hashlib
 from collections import Counter
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -262,6 +263,7 @@ def _provenance(
         "candidate_library_contract_version": CANDIDATE_LIBRARY_CONTRACT_VERSION,
         "source_name": source_name,
         "input_path": str(input_path) if input_path is not None else None,
+        "input_file": _file_facts(Path(input_path)) if input_path is not None else None,
         "input_rows": artifacts.input_count,
         "output_rows": artifacts.output_count,
         "input_columns": list(source_df.columns),
@@ -282,6 +284,24 @@ def _provenance(
 
 def _write_json(payload: dict[str, Any], path: Path) -> None:
     path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _file_facts(path: Path) -> dict[str, Any]:
+    exists = path.exists()
+    return {
+        "path": str(path),
+        "exists": exists,
+        "size_bytes": path.stat().st_size if exists and path.is_file() else None,
+        "sha256": _sha256(path) if exists and path.is_file() else None,
+    }
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 def _text(value: Any) -> str:

--- a/tests/test_candidate_library_builder.py
+++ b/tests/test_candidate_library_builder.py
@@ -107,6 +107,10 @@ def test_builder_normalizes_lightweight_source_table_and_writes_provenance(tmp_p
     provenance = json.loads(artifacts.provenance_json.read_text(encoding="utf-8"))
     assert provenance["network_access"] == "not_used"
     assert provenance["does_not_generate_candidates"] is True
+    assert provenance["input_file"]["path"].endswith("real_vendor_fixture.csv")
+    assert provenance["input_file"]["exists"] is True
+    assert provenance["input_file"]["size_bytes"] > 0
+    assert len(provenance["input_file"]["sha256"]) == 64
     assert provenance["outputs"]["candidate_library_csv"] == "candidate_library.csv"
 
 

--- a/tests/test_research_package_runner.py
+++ b/tests/test_research_package_runner.py
@@ -110,11 +110,24 @@ def test_research_package_runner_generates_all_scientific_artifacts(tmp_path):
     assert package_manifest["candidate_library_rows"] == 1
     assert package_manifest["ranked_candidates"] == 1
     assert package_manifest["publication_grade"] is False
+    assert package_manifest["schema_version"] == "research-package-manifest-v1"
     assert package_manifest["verification_level"] == "source_columns_only"
     assert package_manifest["source_columns_is_smoke_only"] is True
     assert package_manifest["max_rows"] is None
     assert package_manifest["max_rows_is_smoke_only"] is False
     assert package_manifest["candidate_pool_contract_version"] == "candidate-library-v1"
+    assert package_manifest["runner"]["name"] == "run_research_package"
+    assert package_manifest["runner"]["args"]["dataset_id"] == "package-fixture"
+    assert package_manifest["runner"]["args"]["evidence_mode"] == "source-columns"
+    assert package_manifest["runner"]["args"]["min_verified_rows"] == 4
+    assert package_manifest["runner"]["args"]["top_k"] == 1
+    assert package_manifest["inputs"]["source_table"]["path"].endswith("raw_psc.csv")
+    assert package_manifest["inputs"]["source_table"]["exists"] is True
+    assert package_manifest["inputs"]["source_table"]["size_bytes"] > 0
+    assert package_manifest["inputs"]["source_table"]["sha256_16"]
+    assert package_manifest["inputs"]["candidate_source"]["path"].endswith("candidate_source.csv")
+    assert package_manifest["inputs"]["candidate_source"]["exists"] is True
+    assert package_manifest["inputs"]["candidate_source"]["sha256_16"]
     assert package_manifest["outputs"]["root_provenance_manifest_json"] == "provenance_manifest.json"
 
     workflow_manifest = json.loads(
@@ -166,6 +179,8 @@ def test_research_package_runner_generates_all_scientific_artifacts(tmp_path):
     assert root_manifest["dataset_id"] == "package-fixture"
     assert root_manifest["strict_verified_training_only"] is True
     assert root_manifest["verified_candidate_discovery_only"] is True
+    assert {item["id"] for item in root_manifest["artifacts"]["package"]} == {"package_manifest_json"}
+    assert root_manifest["source_manifests"]["package_manifest_json"]["exists"] is True
     assert "candidate_library:candidate_library_csv" in {
         item["id"] for item in root_manifest["artifacts"]["discovery"]
     }

--- a/tests/test_research_package_runner.py
+++ b/tests/test_research_package_runner.py
@@ -124,10 +124,11 @@ def test_research_package_runner_generates_all_scientific_artifacts(tmp_path):
     assert package_manifest["inputs"]["source_table"]["path"].endswith("raw_psc.csv")
     assert package_manifest["inputs"]["source_table"]["exists"] is True
     assert package_manifest["inputs"]["source_table"]["size_bytes"] > 0
-    assert package_manifest["inputs"]["source_table"]["sha256_16"]
+    assert len(package_manifest["inputs"]["source_table"]["sha256"]) == 64
     assert package_manifest["inputs"]["candidate_source"]["path"].endswith("candidate_source.csv")
+    assert package_manifest["inputs"]["candidate_source"]["source_name"] == "fixture-vendor-source"
     assert package_manifest["inputs"]["candidate_source"]["exists"] is True
-    assert package_manifest["inputs"]["candidate_source"]["sha256_16"]
+    assert len(package_manifest["inputs"]["candidate_source"]["sha256"]) == 64
     assert package_manifest["outputs"]["root_provenance_manifest_json"] == "provenance_manifest.json"
 
     workflow_manifest = json.loads(
@@ -142,6 +143,9 @@ def test_research_package_runner_generates_all_scientific_artifacts(tmp_path):
     )
     assert candidate_provenance["network_access"] == "not_used"
     assert candidate_provenance["does_not_generate_candidates"] is True
+    assert candidate_provenance["input_file"]["path"].endswith("candidate_source.csv")
+    assert candidate_provenance["input_file"]["exists"] is True
+    assert len(candidate_provenance["input_file"]["sha256"]) == 64
     assert candidate_provenance["validation"]["status"] == "passed"
 
     report_text = (package.report_dir / "main_text" / "main_text_report.md").read_text(encoding="utf-8")
@@ -181,6 +185,10 @@ def test_research_package_runner_generates_all_scientific_artifacts(tmp_path):
     assert root_manifest["verified_candidate_discovery_only"] is True
     assert {item["id"] for item in root_manifest["artifacts"]["package"]} == {"package_manifest_json"}
     assert root_manifest["source_manifests"]["package_manifest_json"]["exists"] is True
+    assert root_manifest["source_inputs"]["input_table"]["path"].endswith("raw_psc.csv")
+    assert len(root_manifest["source_inputs"]["input_table"]["sha256"]) == 64
+    assert root_manifest["source_inputs"]["candidate_source_table"]["path"].endswith("candidate_source.csv")
+    assert len(root_manifest["source_inputs"]["candidate_source_table"]["sha256"]) == 64
     assert "candidate_library:candidate_library_csv" in {
         item["id"] for item in root_manifest["artifacts"]["discovery"]
     }

--- a/tests/test_root_provenance_manifest.py
+++ b/tests/test_root_provenance_manifest.py
@@ -45,12 +45,17 @@ def test_root_provenance_manifest_indexes_verified_discovery_report_and_si(tmp_p
     _write(candidate_library_dir / "candidate_library.csv", "candidate_id,smiles\ncand-001,C\n")
     _write(candidate_library_dir / "source_summary.json", '{"output_rows": 1}\n')
     _write(candidate_library_dir / "provenance.json", '{"network_access": "not_used"}\n')
+    package_manifest = _write(
+        tmp_path / "package_manifest.json",
+        '{"schema_version": "research-package-manifest-v1"}\n',
+    )
 
     manifest = generate_root_provenance_manifest(
         discovery_dir,
         report_dir,
         si_dir,
         candidate_library_dir=candidate_library_dir,
+        package_manifest_path=package_manifest,
     )
 
     output_path = tmp_path / "report_bundle" / "provenance_manifest.json"
@@ -77,6 +82,8 @@ def test_root_provenance_manifest_indexes_verified_discovery_report_and_si(tmp_p
     assert {item["id"] for item in manifest["artifacts"]["SI"]} == {"supplementary_information_md"}
     assert {item["id"] for item in manifest["artifacts"]["claim"]} == {"claim_ledger_json"}
     assert {item["id"] for item in manifest["artifacts"]["review"]} == {"review_report_json"}
+    assert {item["id"] for item in manifest["artifacts"]["package"]} == {"package_manifest_json"}
+    assert manifest["source_manifests"]["package_manifest_json"]["exists"] is True
 
     verified_train = manifest["artifacts"]["dataset"][0]
     assert verified_train["exists"] is True

--- a/tests/test_root_provenance_manifest.py
+++ b/tests/test_root_provenance_manifest.py
@@ -36,12 +36,14 @@ def test_root_provenance_manifest_indexes_verified_discovery_report_and_si(tmp_p
     _write(discovery_dir / "model" / "model_manifest.json", '{"strict_verified_training_only": true}\n')
     _write(discovery_dir / "discovery" / "ranked_candidates.csv", "rank,candidate_id\n1,cand-001\n")
     _write(discovery_dir / "discovery" / "audit_report.md", "# Audit\nverified-only\n")
+    input_table = _write(tmp_path / "raw_source.csv", "doi,smiles\n10.1/example,C\n")
     _write(report_dir / "main_text.md", "# Main report\n")
     _write(report_dir / "claim_ledger.json", '[{"evidence_id": "metric:best_model.r2"}]\n')
     _write(report_dir / "review_report.json", '{"review": {"passed": true}}\n')
     _write(si_dir / "supplementary_information.md", "# SI\n")
     _write(si_dir / "audit_summary.json", '{"passed": true}\n')
     candidate_library_dir = tmp_path / "candidate_library"
+    candidate_source = _write(tmp_path / "candidate_source.csv", "candidate_id,smiles\ncand-001,C\n")
     _write(candidate_library_dir / "candidate_library.csv", "candidate_id,smiles\ncand-001,C\n")
     _write(candidate_library_dir / "source_summary.json", '{"output_rows": 1}\n')
     _write(candidate_library_dir / "provenance.json", '{"network_access": "not_used"}\n')
@@ -56,6 +58,8 @@ def test_root_provenance_manifest_indexes_verified_discovery_report_and_si(tmp_p
         si_dir,
         candidate_library_dir=candidate_library_dir,
         package_manifest_path=package_manifest,
+        input_path=input_table,
+        candidate_source_path=candidate_source,
     )
 
     output_path = tmp_path / "report_bundle" / "provenance_manifest.json"
@@ -84,6 +88,10 @@ def test_root_provenance_manifest_indexes_verified_discovery_report_and_si(tmp_p
     assert {item["id"] for item in manifest["artifacts"]["review"]} == {"review_report_json"}
     assert {item["id"] for item in manifest["artifacts"]["package"]} == {"package_manifest_json"}
     assert manifest["source_manifests"]["package_manifest_json"]["exists"] is True
+    assert manifest["source_inputs"]["input_table"]["path"].endswith("raw_source.csv")
+    assert len(manifest["source_inputs"]["input_table"]["sha256"]) == 64
+    assert manifest["source_inputs"]["candidate_source_table"]["path"].endswith("candidate_source.csv")
+    assert len(manifest["source_inputs"]["candidate_source_table"]["sha256"]) == 64
 
     verified_train = manifest["artifacts"]["dataset"][0]
     assert verified_train["exists"] is True


### PR DESCRIPTION
## Summary
- Add research-package manifest schema/version, runner args, and full SHA256 input file facts for source tables and candidate-source tables.
- Index package_manifest.json in the root provenance manifest as a package artifact and source manifest.
- Add full SHA256 source input binding to root provenance and candidate-library provenance.
- Reorder package generation so root provenance includes the package manifest without a missing-file gap.

## Verification
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_research_package_runner.py tests/test_root_provenance_manifest.py tests/test_run_verified_discovery_cli.py tests/test_candidate_library_builder.py tests/test_evidence_cache_verifiers.py -> 15 passed
- python -m py_compile hybrid_agent_exploration/src/run_research_package.py hybrid_agent_exploration/src/reporting/root_provenance_manifest.py hybrid_agent_exploration/src/screening/candidate_library_builder.py
- git diff --check
- Real source-columns 500-row package smoke wrote package_manifest.json and provenance_manifest.json with full source/candidate SHA256 values and package_manifest_json indexed.