### PR TITLE
fix: require explicit candidate verification status

### DIFF
--- a/hybrid_agent_exploration/src/reporting/si_generator.py
+++ b/hybrid_agent_exploration/src/reporting/si_generator.py
@@ -410,6 +410,8 @@ class SIGenerator:
             f"Evidence mode: `{context.get('evidence_mode', 'unknown')}`.",
             f"Verification level: `{context.get('verification_level', 'unknown')}`.",
             f"Publication-grade flag: `{context.get('publication_grade', False)}`.",
+            f"Dataset publication-grade flag: `{context.get('dataset_publication_grade', False)}`.",
+            f"Candidate-library publication-grade flag: `{context.get('candidate_library_publication_grade', False)}`.",
         ]
         if context.get("source_columns_is_smoke_only"):
             lines.append(

--- a/hybrid_agent_exploration/src/run_research_package.py
+++ b/hybrid_agent_exploration/src/run_research_package.py
@@ -84,7 +84,7 @@ def run_research_package(
         candidate_library_rows = candidate_artifacts.output_count
 
     verification_level = _verification_level(evidence_mode)
-    dataset_publication_grade = evidence_mode == "external-cached"
+    dataset_publication_grade = evidence_mode == "external-cached" and max_rows is None
     candidate_library_publication_grade = candidate_source_path is None
     publication_grade = dataset_publication_grade and candidate_library_publication_grade
     run_metadata = {

--- a/hybrid_agent_exploration/src/run_research_package.py
+++ b/hybrid_agent_exploration/src/run_research_package.py
@@ -84,10 +84,15 @@ def run_research_package(
         candidate_library_rows = candidate_artifacts.output_count
 
     verification_level = _verification_level(evidence_mode)
+    dataset_publication_grade = evidence_mode == "external-cached"
+    candidate_library_publication_grade = candidate_source_path is None
+    publication_grade = dataset_publication_grade and candidate_library_publication_grade
     run_metadata = {
         "evidence_mode": evidence_mode,
         "verification_level": verification_level,
-        "publication_grade": evidence_mode == "external-cached",
+        "publication_grade": publication_grade,
+        "dataset_publication_grade": dataset_publication_grade,
+        "candidate_library_publication_grade": candidate_library_publication_grade,
         "source_columns_is_smoke_only": evidence_mode == "source-columns",
         "input_path": str(Path(input_path)),
         "max_rows": max_rows,
@@ -117,7 +122,9 @@ def run_research_package(
         evidence_context={
             "evidence_mode": evidence_mode,
             "verification_level": verification_level,
-            "publication_grade": evidence_mode == "external-cached",
+            "publication_grade": publication_grade,
+            "dataset_publication_grade": dataset_publication_grade,
+            "candidate_library_publication_grade": candidate_library_publication_grade,
             "source_columns_is_smoke_only": evidence_mode == "source-columns",
             "max_rows": max_rows,
             "max_rows_is_smoke_only": max_rows is not None,
@@ -144,6 +151,9 @@ def run_research_package(
             dataset_id=dataset_id,
             output_root=output_root,
             evidence_mode=evidence_mode,
+            dataset_publication_grade=dataset_publication_grade,
+            candidate_library_publication_grade=candidate_library_publication_grade,
+            publication_grade=publication_grade,
             input_path=Path(input_path),
             candidate_source_path=Path(candidate_source_path) if candidate_source_path is not None else None,
             candidate_source_name=candidate_source_name,
@@ -242,6 +252,9 @@ def _package_manifest(
     dataset_id: str,
     output_root: Path,
     evidence_mode: str,
+    dataset_publication_grade: bool,
+    candidate_library_publication_grade: bool,
+    publication_grade: bool,
     input_path: Path,
     candidate_source_path: Path | None,
     candidate_source_name: str | None,
@@ -296,7 +309,9 @@ def _package_manifest(
         },
         "evidence_mode": evidence_mode,
         "verification_level": verification_level,
-        "publication_grade": evidence_mode == "external-cached",
+        "publication_grade": publication_grade,
+        "dataset_publication_grade": dataset_publication_grade,
+        "candidate_library_publication_grade": candidate_library_publication_grade,
         "source_columns_is_smoke_only": evidence_mode == "source-columns",
         "max_rows": max_rows,
         "max_rows_is_smoke_only": max_rows is not None,

--- a/hybrid_agent_exploration/src/screening/candidate_library_builder.py
+++ b/hybrid_agent_exploration/src/screening/candidate_library_builder.py
@@ -152,7 +152,7 @@ def _normalize_row(row: dict[str, Any], *, source_name: str) -> dict[str, Any]:
         "availability_status": _status(canonical, "availability_status"),
         "synthesis_status": _status(canonical, "synthesis_status"),
         "safety_status": _status(canonical, "safety_status"),
-        "verification_status": _text(canonical.get("verification_status")) or "verified",
+        "verification_status": _text(canonical.get("verification_status")),
         "verification_sources": json.dumps(verification_sources, ensure_ascii=False, sort_keys=True),
         "pubchem_id": _text(canonical.get("pubchem_id")),
         "cas_number": _text(canonical.get("cas_number")),
@@ -270,6 +270,9 @@ def _provenance(
         "output_columns": list(normalized_df.columns),
         "network_access": "not_used",
         "does_not_generate_candidates": True,
+        "publication_grade": False,
+        "publication_grade_reason": "offline candidate-library normalization does not re-verify candidate identities or availability",
+        "verification_status_policy": "explicit_verified_only",
         "validation": {
             "function": "screening.verified_candidate_discovery.validate_candidate_library_contract",
             "status": "passed",

--- a/hybrid_agent_exploration/src/screening/candidate_library_builder.py
+++ b/hybrid_agent_exploration/src/screening/candidate_library_builder.py
@@ -21,6 +21,7 @@ import pandas as pd
 from screening.verified_candidate_discovery import (
     CANDIDATE_LIBRARY_CONTRACT_VERSION,
     CANDIDATE_LIBRARY_REQUIRED_COLUMNS,
+    CandidateLibraryContractError,
     validate_candidate_library_contract,
 )
 
@@ -101,6 +102,7 @@ class CandidateLibraryBuilder:
         """Normalize a source dataframe and validate it against candidate-library-v1."""
 
         normalized = _normalize_source_table(df, source_name=source_name)
+        _require_explicit_verified_status(normalized)
         validate_candidate_library_contract(normalized)
 
         self.output_dir.mkdir(parents=True, exist_ok=True)
@@ -138,6 +140,18 @@ def _load_table(path: Path) -> pd.DataFrame:
 def _normalize_source_table(df: pd.DataFrame, *, source_name: str) -> pd.DataFrame:
     rows = [_normalize_row(row, source_name=source_name) for row in df.to_dict(orient="records")]
     return pd.DataFrame(rows, columns=OUTPUT_COLUMNS)
+
+
+def _require_explicit_verified_status(df: pd.DataFrame) -> None:
+    statuses = df["verification_status"].map(_text)
+    bad = df[statuses != "verified"]
+    if bad.empty:
+        return
+    identifiers = bad["candidate_id"].map(_text).head(10).tolist()
+    raise CandidateLibraryContractError(
+        "Candidate library builder requires verification_status=verified for every row; "
+        f"blocked rows: {', '.join(identifiers)}"
+    )
 
 
 def _normalize_row(row: dict[str, Any], *, source_name: str) -> dict[str, Any]:

--- a/tests/test_candidate_library_builder.py
+++ b/tests/test_candidate_library_builder.py
@@ -23,6 +23,7 @@ def _source_rows() -> pd.DataFrame:
                 "availability": "commercial",
                 "synthesis": "commercial",
                 "safety": "sds_available",
+                "verification_status": "verified",
                 "verification_sources": json.dumps(
                     [
                         {"kind": "molecule", "source": "pubchem", "pubchem_id": "702"},
@@ -45,6 +46,7 @@ def _source_rows() -> pd.DataFrame:
                 "availability": "commercial",
                 "synthesis": "commercial",
                 "safety": "sds_available",
+                "verification_status": "verified",
                 "verification_sources": json.dumps(
                     [
                         {"kind": "molecule", "source": "pubchem", "pubchem_id": "8471"},
@@ -130,3 +132,33 @@ def test_builder_rejects_rows_without_real_verification_sources(tmp_path):
 
     assert "verification_sources" in str(exc.value)
     assert "pubchem-vendor-fixture:pubchem-702" in str(exc.value)
+
+
+def test_builder_rejects_missing_explicit_verification_status(tmp_path):
+    from screening.candidate_library_builder import CandidateLibraryBuilder
+    from screening.verified_candidate_discovery import CandidateLibraryContractError
+
+    rows = _source_rows().drop(columns=["verification_status"])
+
+    with pytest.raises(CandidateLibraryContractError) as exc:
+        CandidateLibraryBuilder(output_dir=tmp_path / "out").build_from_dataframe(
+            rows,
+            dataset_id="missing-status",
+            source_name="pubchem-vendor-fixture",
+        )
+
+    assert "verification_status" in str(exc.value)
+    assert "pubchem-vendor-fixture:pubchem-702" in str(exc.value)
+
+
+def test_builder_records_explicit_verified_status_policy(tmp_path):
+    from screening.candidate_library_builder import CandidateLibraryBuilder
+
+    artifacts = CandidateLibraryBuilder(output_dir=tmp_path / "out").build_from_dataframe(
+        _source_rows(),
+        dataset_id="explicit-status",
+        source_name="pubchem-vendor-fixture",
+    )
+
+    provenance = json.loads(artifacts.provenance_json.read_text(encoding="utf-8"))
+    assert provenance["verification_status_policy"] == "explicit_verified_only"

--- a/tests/test_candidate_library_builder.py
+++ b/tests/test_candidate_library_builder.py
@@ -151,6 +151,24 @@ def test_builder_rejects_missing_explicit_verification_status(tmp_path):
     assert "pubchem-vendor-fixture:pubchem-702" in str(exc.value)
 
 
+def test_builder_rejects_explicit_non_verified_status(tmp_path):
+    from screening.candidate_library_builder import CandidateLibraryBuilder
+    from screening.verified_candidate_discovery import CandidateLibraryContractError
+
+    rows = _source_rows()
+    rows.loc[0, "verification_status"] = "manual_review"
+
+    with pytest.raises(CandidateLibraryContractError) as exc:
+        CandidateLibraryBuilder(output_dir=tmp_path / "out").build_from_dataframe(
+            rows,
+            dataset_id="non-verified-status",
+            source_name="pubchem-vendor-fixture",
+        )
+
+    assert "verification_status=verified" in str(exc.value)
+    assert "pubchem-vendor-fixture:pubchem-702" in str(exc.value)
+
+
 def test_builder_records_explicit_verified_status_policy(tmp_path):
     from screening.candidate_library_builder import CandidateLibraryBuilder
 

--- a/tests/test_research_package_runner.py
+++ b/tests/test_research_package_runner.py
@@ -256,3 +256,52 @@ def test_external_cached_candidate_source_does_not_overclaim_publication_grade(t
     si_text = (package.report_dir / "si" / "supporting_information.md").read_text(encoding="utf-8")
     assert "Publication-grade flag: `False`" in si_text
     assert "Candidate-library publication-grade flag: `False`" in si_text
+
+
+def test_external_cached_max_rows_does_not_overclaim_publication_grade(tmp_path, monkeypatch):
+    import run_research_package as runner
+    from harness.authenticity import RealDataAuthenticator
+    from run_verified_discovery import SourceColumnMoleculeVerifier, SourceColumnReferenceVerifier
+
+    raw_csv = tmp_path / "raw_psc.csv"
+    pd.DataFrame(
+        [
+            _raw_record("row-001", "10.1021/acs.jpclett.6c00119", "C", 0.25),
+            _raw_record("row-002", "10.1021/acs.jpclett.6c00120", "CC", 0.50),
+            _raw_record("row-003", "10.1021/acs.jpclett.6c00121", "CCC", 0.75),
+            _raw_record("row-004", "10.1021/acs.jpclett.6c00122", "CCCC", 1.00),
+            _raw_record("row-005", "10.1021/acs.jpclett.6c00123", "CCO", 0.40),
+        ]
+    ).to_csv(raw_csv, index=False)
+
+    def build_source_column_authenticator(evidence_mode, df, cache_dir):
+        return RealDataAuthenticator(
+            reference_verifier=SourceColumnReferenceVerifier(df),
+            molecule_verifier=SourceColumnMoleculeVerifier(),
+        )
+
+    monkeypatch.setattr(runner, "build_authenticator", build_source_column_authenticator)
+
+    package = runner.run_research_package(
+        input_path=raw_csv,
+        output_dir=tmp_path / "research_package",
+        dataset_id="external-cached-smoke",
+        evidence_mode="external-cached",
+        max_rows=4,
+        min_verified_rows=4,
+        top_k=1,
+    )
+
+    package_manifest = json.loads(package.package_manifest_json.read_text(encoding="utf-8"))
+    assert package_manifest["max_rows"] == 4
+    assert package_manifest["max_rows_is_smoke_only"] is True
+    assert package_manifest["dataset_publication_grade"] is False
+    assert package_manifest["candidate_library_publication_grade"] is True
+    assert package_manifest["publication_grade"] is False
+
+    run_manifest = json.loads(
+        (package.report_dir / "main_text" / "run_manifest.json").read_text(encoding="utf-8")
+    )
+    assert run_manifest["evidence_context"]["max_rows_is_smoke_only"] is True
+    assert run_manifest["evidence_context"]["dataset_publication_grade"] is False
+    assert run_manifest["evidence_context"]["publication_grade"] is False

--- a/tests/test_research_package_runner.py
+++ b/tests/test_research_package_runner.py
@@ -38,6 +38,7 @@ def _candidate_source() -> pd.DataFrame:
                 "availability": "commercial",
                 "synthesis": "commercial",
                 "safety": "sds_available",
+                "verification_status": "verified",
                 "verification_sources": json.dumps(
                     [
                         {"kind": "molecule", "source": "pubchem", "pubchem_id": "7843"},
@@ -110,6 +111,8 @@ def test_research_package_runner_generates_all_scientific_artifacts(tmp_path):
     assert package_manifest["candidate_library_rows"] == 1
     assert package_manifest["ranked_candidates"] == 1
     assert package_manifest["publication_grade"] is False
+    assert package_manifest["dataset_publication_grade"] is False
+    assert package_manifest["candidate_library_publication_grade"] is False
     assert package_manifest["schema_version"] == "research-package-manifest-v1"
     assert package_manifest["verification_level"] == "source_columns_only"
     assert package_manifest["source_columns_is_smoke_only"] is True
@@ -143,6 +146,8 @@ def test_research_package_runner_generates_all_scientific_artifacts(tmp_path):
     )
     assert candidate_provenance["network_access"] == "not_used"
     assert candidate_provenance["does_not_generate_candidates"] is True
+    assert candidate_provenance["publication_grade"] is False
+    assert candidate_provenance["verification_status_policy"] == "explicit_verified_only"
     assert candidate_provenance["input_file"]["path"].endswith("candidate_source.csv")
     assert candidate_provenance["input_file"]["exists"] is True
     assert len(candidate_provenance["input_file"]["sha256"]) == 64
@@ -172,11 +177,13 @@ def test_research_package_runner_generates_all_scientific_artifacts(tmp_path):
     assert run_manifest["best_model"]["pearson_r"] is None
     assert run_manifest["evidence_context"]["source_columns_is_smoke_only"] is True
     assert run_manifest["evidence_context"]["metric_scope"] == "training_only"
+    assert run_manifest["evidence_context"]["candidate_library_publication_grade"] is False
 
     si_text = (package.report_dir / "si" / "supporting_information.md").read_text(encoding="utf-8")
     assert "source-columns" in si_text
     assert "smoke-only" in si_text
     assert "training-only" in si_text
+    assert "Candidate-library publication-grade flag: `False`" in si_text
     assert "Cross-validation was not supplied" in si_text
 
     root_manifest = json.loads(package.root_provenance_manifest_json.read_text(encoding="utf-8"))
@@ -196,3 +203,56 @@ def test_research_package_runner_generates_all_scientific_artifacts(tmp_path):
     ranked = pd.read_csv(package.verified_discovery_dir / "discovery" / "ranked_candidates.csv")
     assert ranked["candidate_id"].tolist() == ["fixture-vendor-source:pubchem-7843"]
     assert "candidate_score" in ranked.columns
+
+
+def test_external_cached_candidate_source_does_not_overclaim_publication_grade(tmp_path, monkeypatch):
+    import run_research_package as runner
+    from harness.authenticity import RealDataAuthenticator
+    from run_verified_discovery import SourceColumnMoleculeVerifier, SourceColumnReferenceVerifier
+
+    raw_csv = tmp_path / "raw_psc.csv"
+    candidate_csv = tmp_path / "candidate_source.csv"
+    pd.DataFrame(
+        [
+            _raw_record("row-001", "10.1021/acs.jpclett.6c00119", "C", 0.25),
+            _raw_record("row-002", "10.1021/acs.jpclett.6c00120", "CC", 0.50),
+            _raw_record("row-003", "10.1021/acs.jpclett.6c00121", "CCC", 0.75),
+            _raw_record("row-004", "10.1021/acs.jpclett.6c00122", "CCCC", 1.00),
+        ]
+    ).to_csv(raw_csv, index=False)
+    _candidate_source().to_csv(candidate_csv, index=False)
+
+    def build_source_column_authenticator(evidence_mode, df, cache_dir):
+        return RealDataAuthenticator(
+            reference_verifier=SourceColumnReferenceVerifier(df),
+            molecule_verifier=SourceColumnMoleculeVerifier(),
+        )
+
+    monkeypatch.setattr(runner, "build_authenticator", build_source_column_authenticator)
+
+    package = runner.run_research_package(
+        input_path=raw_csv,
+        output_dir=tmp_path / "research_package",
+        dataset_id="external-cached-offline-candidates",
+        evidence_mode="external-cached",
+        candidate_source_path=candidate_csv,
+        candidate_source_name="fixture-vendor-source",
+        min_verified_rows=4,
+        top_k=1,
+    )
+
+    package_manifest = json.loads(package.package_manifest_json.read_text(encoding="utf-8"))
+    assert package_manifest["dataset_publication_grade"] is True
+    assert package_manifest["candidate_library_publication_grade"] is False
+    assert package_manifest["publication_grade"] is False
+
+    run_manifest = json.loads(
+        (package.report_dir / "main_text" / "run_manifest.json").read_text(encoding="utf-8")
+    )
+    assert run_manifest["evidence_context"]["publication_grade"] is False
+    assert run_manifest["evidence_context"]["dataset_publication_grade"] is True
+    assert run_manifest["evidence_context"]["candidate_library_publication_grade"] is False
+
+    si_text = (package.report_dir / "si" / "supporting_information.md").read_text(encoding="utf-8")
+    assert "Publication-grade flag: `False`" in si_text
+    assert "Candidate-library publication-grade flag: `False`" in si_text


### PR DESCRIPTION
## Summary
- require offline candidate-source rows to carry explicit  instead of defaulting missing status to verified
- mark offline candidate-library normalization as non-publication-grade in provenance
- propagate dataset and candidate-library publication-grade subflags into package manifests and SI

## Verification
- ...................                                                      [100%]
19 passed in 7.93s
- 
- real 500-row source-columns smoke package with explicit candidate-source verification status: package/candidate-library flags stayed non-publication-grade