### PR TITLE
feat: report source completeness artifacts

### DIFF
--- a/hybrid_agent_exploration/src/data/source_completeness.py
+++ b/hybrid_agent_exploration/src/data/source_completeness.py
@@ -88,11 +88,13 @@ def summarize_source_completeness(
     *,
     dataset_id: str,
     source_name: str,
+    max_rows: int | None = None,
     expected_groups: tuple[tuple[str, str, tuple[str, ...]], ...] | None = None,
 ) -> dict[str, Any]:
     """Summarize source-column missingness for a PSC input table."""
 
     row_count = int(len(df))
+    max_rows_is_smoke_only = max_rows is not None
     groups = [
         _summarize_group(df, row_count=row_count, group_id=group_id, label=label, columns=columns)
         for group_id, label, columns in (expected_groups or DEFAULT_SOURCE_GROUPS)
@@ -114,6 +116,9 @@ def summarize_source_completeness(
         "dataset_id": dataset_id,
         "source_name": source_name,
         "row_count": row_count,
+        "max_rows": max_rows,
+        "max_rows_is_smoke_only": max_rows_is_smoke_only,
+        "audit_population": "max_rows_subset" if max_rows_is_smoke_only else "loaded_source_table",
         "audit_scope": AUDIT_SCOPE,
         "external_verification": False,
         "interpretation": (
@@ -164,11 +169,18 @@ def format_source_completeness_markdown(summary: dict[str, Any]) -> str:
         f"- Dataset: `{summary.get('dataset_id', 'unknown')}`",
         f"- Source: `{summary.get('source_name', 'unknown')}`",
         f"- Rows audited: `{summary.get('row_count', 0)}`",
+        f"- Audit population: `{summary.get('audit_population', 'loaded_source_table')}`",
         f"- Overall completeness fraction: `{overall.get('completeness_fraction', 0.0)}`",
         "",
         "| Group | Column | Present | Non-missing | Missing | Completeness |",
         "|-------|--------|---------|-------------|---------|--------------|",
     ]
+    if summary.get("max_rows_is_smoke_only"):
+        lines.insert(
+            4,
+            "This audit covers a smoke-only subset selected by `max_rows`; it is not a full-source audit.",
+        )
+        lines.insert(5, "")
     for row in _flatten_rows(summary):
         present = "yes" if row["present"] else "no"
         lines.append(
@@ -187,6 +199,9 @@ def compact_source_completeness(summary: dict[str, Any]) -> dict[str, Any]:
         "dataset_id": summary.get("dataset_id"),
         "source_name": summary.get("source_name"),
         "row_count": summary.get("row_count"),
+        "max_rows": summary.get("max_rows"),
+        "max_rows_is_smoke_only": summary.get("max_rows_is_smoke_only"),
+        "audit_population": summary.get("audit_population"),
         "audit_scope": summary.get("audit_scope"),
         "external_verification": summary.get("external_verification"),
         "overall": summary.get("overall", {}),

--- a/hybrid_agent_exploration/src/data/source_completeness.py
+++ b/hybrid_agent_exploration/src/data/source_completeness.py
@@ -1,0 +1,300 @@
+"""Column-level source completeness audit for PSC research packages.
+
+This module reports missingness in the input table only. It does not verify DOI,
+molecule, supplier, or experimental claims against external services.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+
+SOURCE_COMPLETENESS_SCHEMA_VERSION = "source-completeness-v1"
+AUDIT_SCOPE = "column_level_missingness_only"
+
+DEFAULT_SOURCE_GROUPS: tuple[tuple[str, str, tuple[str, ...]], ...] = (
+    (
+        "literature_metadata",
+        "Literature metadata",
+        (
+            "title",
+            "authors",
+            "journal",
+            "volume",
+            "issue",
+            "pages",
+            "doi",
+            "abstract",
+            "publisher",
+            "publication_date",
+            "funding_info",
+            "references_count",
+            "is_referenced_by_count",
+        ),
+    ),
+    (
+        "chemical_identity",
+        "Chemical identity",
+        ("cas_number", "pubchem_id", "smiles", "molecular_formula"),
+    ),
+    (
+        "molecular_descriptors",
+        "Molecular descriptors",
+        ("molecular_weight", "h_bond_donors", "h_bond_acceptors", "rotatable_bonds", "tpsa", "log_p"),
+    ),
+    (
+        "jv_core",
+        "JV device metrics",
+        (
+            "jv_reverse_scan_pce_without_modulator",
+            "jv_reverse_scan_j_sc_without_modulator",
+            "jv_reverse_scan_v_oc_without_modulator",
+            "jv_reverse_scan_ff_without_modulator",
+            "jv_reverse_scan_pce",
+            "jv_reverse_scan_j_sc",
+            "jv_reverse_scan_v_oc",
+            "jv_reverse_scan_ff",
+            "jv_hysteresis_index_without_modulator",
+            "jv_hysteresis_index",
+        ),
+    ),
+    (
+        "target_derivation",
+        "Target derivation",
+        ("delta_pce", "jv_reverse_scan_pce", "jv_reverse_scan_pce_without_modulator"),
+    ),
+)
+
+
+@dataclass(frozen=True)
+class SourceCompletenessArtifacts:
+    """Paths emitted by a source completeness audit."""
+
+    output_dir: Path
+    summary_json: Path
+    table_csv: Path
+    markdown: Path
+    summary: dict[str, Any]
+
+
+def summarize_source_completeness(
+    df: pd.DataFrame,
+    *,
+    dataset_id: str,
+    source_name: str,
+    expected_groups: tuple[tuple[str, str, tuple[str, ...]], ...] | None = None,
+) -> dict[str, Any]:
+    """Summarize source-column missingness for a PSC input table."""
+
+    row_count = int(len(df))
+    groups = [
+        _summarize_group(df, row_count=row_count, group_id=group_id, label=label, columns=columns)
+        for group_id, label, columns in (expected_groups or DEFAULT_SOURCE_GROUPS)
+    ]
+    present_columns = sum(group["present_columns"] for group in groups)
+    expected_columns = sum(group["expected_columns"] for group in groups)
+    available_cells = sum(group["available_cells"] for group in groups)
+    total_cells = sum(group["total_cells"] for group in groups)
+    overall_fraction = _fraction(available_cells, total_cells)
+    missing_expected_columns = [
+        {"group_id": group["id"], "column": column["column"]}
+        for group in groups
+        for column in group["columns"]
+        if not column["present"]
+    ]
+    return {
+        "schema_version": SOURCE_COMPLETENESS_SCHEMA_VERSION,
+        "generated_at": _now_iso(),
+        "dataset_id": dataset_id,
+        "source_name": source_name,
+        "row_count": row_count,
+        "audit_scope": AUDIT_SCOPE,
+        "external_verification": False,
+        "interpretation": (
+            "This is a column-level missingness audit of the supplied table, not external verification "
+            "of DOI, molecule, supplier, or device claims."
+        ),
+        "overall": {
+            "expected_columns": expected_columns,
+            "present_columns": present_columns,
+            "available_cells": available_cells,
+            "total_cells": total_cells,
+            "completeness_fraction": overall_fraction,
+        },
+        "missing_expected_columns": missing_expected_columns,
+        "groups": groups,
+    }
+
+
+def write_source_completeness_artifacts(summary: dict[str, Any], output_dir: str | Path) -> SourceCompletenessArtifacts:
+    """Write JSON, CSV, and Markdown source-completeness artifacts."""
+
+    root = Path(output_dir)
+    root.mkdir(parents=True, exist_ok=True)
+    summary_json = root / "source_completeness.json"
+    table_csv = root / "source_completeness.csv"
+    markdown = root / "source_completeness.md"
+    summary_json.write_text(json.dumps(summary, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    pd.DataFrame(_flatten_rows(summary)).to_csv(table_csv, index=False)
+    markdown.write_text(format_source_completeness_markdown(summary), encoding="utf-8")
+    return SourceCompletenessArtifacts(
+        output_dir=root,
+        summary_json=summary_json,
+        table_csv=table_csv,
+        markdown=markdown,
+        summary=summary,
+    )
+
+
+def format_source_completeness_markdown(summary: dict[str, Any]) -> str:
+    """Format a source completeness summary as a compact Markdown table."""
+
+    overall = summary.get("overall", {})
+    lines = [
+        "# Source Completeness Audit",
+        "",
+        "This is a column-level missingness audit of the supplied source table; it is not external verification of DOI, molecule, supplier, or device claims.",
+        "",
+        f"- Dataset: `{summary.get('dataset_id', 'unknown')}`",
+        f"- Source: `{summary.get('source_name', 'unknown')}`",
+        f"- Rows audited: `{summary.get('row_count', 0)}`",
+        f"- Overall completeness fraction: `{overall.get('completeness_fraction', 0.0)}`",
+        "",
+        "| Group | Column | Present | Non-missing | Missing | Completeness |",
+        "|-------|--------|---------|-------------|---------|--------------|",
+    ]
+    for row in _flatten_rows(summary):
+        present = "yes" if row["present"] else "no"
+        lines.append(
+            f"| {row['group_id']} | {row['column']} | {present} | {row['non_missing']} | "
+            f"{row['missing']} | {row['completeness_fraction']} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def compact_source_completeness(summary: dict[str, Any]) -> dict[str, Any]:
+    """Return a small report-manifest friendly source completeness summary."""
+
+    return {
+        "schema_version": summary.get("schema_version"),
+        "dataset_id": summary.get("dataset_id"),
+        "source_name": summary.get("source_name"),
+        "row_count": summary.get("row_count"),
+        "audit_scope": summary.get("audit_scope"),
+        "external_verification": summary.get("external_verification"),
+        "overall": summary.get("overall", {}),
+        "groups": [
+            {
+                "id": group.get("id"),
+                "label": group.get("label"),
+                "expected_columns": group.get("expected_columns"),
+                "present_columns": group.get("present_columns"),
+                "completeness_fraction": group.get("completeness_fraction"),
+                "lowest_completeness_columns": _lowest_columns(group.get("columns", [])),
+            }
+            for group in summary.get("groups", [])
+        ],
+    }
+
+
+def _summarize_group(
+    df: pd.DataFrame,
+    *,
+    row_count: int,
+    group_id: str,
+    label: str,
+    columns: tuple[str, ...],
+) -> dict[str, Any]:
+    column_summaries = [_summarize_column(df, row_count=row_count, column=column) for column in columns]
+    present_columns = sum(1 for column in column_summaries if column["present"])
+    available_cells = sum(column["non_missing"] for column in column_summaries)
+    total_cells = sum(column["total"] for column in column_summaries)
+    return {
+        "id": group_id,
+        "label": label,
+        "expected_columns": len(columns),
+        "present_columns": present_columns,
+        "available_cells": available_cells,
+        "total_cells": total_cells,
+        "completeness_fraction": _fraction(available_cells, total_cells),
+        "columns": column_summaries,
+    }
+
+
+def _summarize_column(df: pd.DataFrame, *, row_count: int, column: str) -> dict[str, Any]:
+    if column not in df.columns:
+        return {
+            "column": column,
+            "present": False,
+            "total": row_count,
+            "non_missing": 0,
+            "missing": row_count,
+            "completeness_fraction": 0.0,
+        }
+    values = df[column]
+    non_missing = int((~values.map(_is_missing)).sum())
+    missing = int(row_count - non_missing)
+    return {
+        "column": column,
+        "present": True,
+        "total": row_count,
+        "non_missing": non_missing,
+        "missing": missing,
+        "completeness_fraction": _fraction(non_missing, row_count),
+    }
+
+
+def _flatten_rows(summary: dict[str, Any]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for group in summary.get("groups", []):
+        for column in group.get("columns", []):
+            rows.append(
+                {
+                    "group_id": group.get("id"),
+                    "group_label": group.get("label"),
+                    "column": column.get("column"),
+                    "present": column.get("present"),
+                    "total": column.get("total"),
+                    "non_missing": column.get("non_missing"),
+                    "missing": column.get("missing"),
+                    "completeness_fraction": column.get("completeness_fraction"),
+                }
+            )
+    return rows
+
+
+def _lowest_columns(columns: list[dict[str, Any]], limit: int = 5) -> list[dict[str, Any]]:
+    return [
+        {
+            "column": column.get("column"),
+            "present": column.get("present"),
+            "missing": column.get("missing"),
+            "completeness_fraction": column.get("completeness_fraction"),
+        }
+        for column in sorted(columns, key=lambda item: (item.get("completeness_fraction", 0.0), item.get("column", "")))[:limit]
+    ]
+
+
+def _is_missing(value: Any) -> bool:
+    if pd.isna(value):
+        return True
+    if isinstance(value, str):
+        return value.strip().lower() in {"", "nan", "none", "null"}
+    return False
+
+
+def _fraction(numerator: int, denominator: int) -> float:
+    if denominator <= 0:
+        return 0.0
+    return round(float(numerator) / float(denominator), 6)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()

--- a/hybrid_agent_exploration/src/reporting/root_provenance_manifest.py
+++ b/hybrid_agent_exploration/src/reporting/root_provenance_manifest.py
@@ -19,7 +19,18 @@ from typing import Any
 MANIFEST_NAME = "provenance_manifest.json"
 SCHEMA_VERSION = "root-provenance-manifest-v1"
 HASH_BYTES_LIMIT = 1024 * 1024
-ARTIFACT_CATEGORIES = ("dataset", "model", "discovery", "report", "SI", "claim", "review", "audit", "package")
+ARTIFACT_CATEGORIES = (
+    "dataset",
+    "model",
+    "discovery",
+    "report",
+    "SI",
+    "claim",
+    "review",
+    "audit",
+    "source_completeness",
+    "package",
+)
 
 
 def generate_root_provenance_manifest(
@@ -28,6 +39,7 @@ def generate_root_provenance_manifest(
     si_dir: str | Path,
     *,
     candidate_library_dir: str | Path | None = None,
+    source_completeness_dir: str | Path | None = None,
     package_manifest_path: str | Path | None = None,
     input_path: str | Path | None = None,
     candidate_source_path: str | Path | None = None,
@@ -41,6 +53,8 @@ def generate_root_provenance_manifest(
         si_dir: Directory containing supplementary information artifacts.
         candidate_library_dir: Optional directory containing candidate_library.csv,
             source_summary.json, and provenance.json from CandidateLibraryBuilder.
+        source_completeness_dir: Optional directory containing source_completeness
+            JSON, CSV, and Markdown artifacts from the package runner.
         package_manifest_path: Optional top-level package_manifest.json emitted by
             run_research_package.
         input_path: Optional original PSC source table used by the package.
@@ -57,6 +71,7 @@ def generate_root_provenance_manifest(
     report_root = Path(report_dir)
     si_root = Path(si_dir)
     candidate_root = Path(candidate_library_dir) if candidate_library_dir is not None else None
+    source_completeness_root = Path(source_completeness_dir) if source_completeness_dir is not None else None
     package_manifest = Path(package_manifest_path) if package_manifest_path is not None else None
     source_input = Path(input_path) if input_path is not None else None
     candidate_source = Path(candidate_source_path) if candidate_source_path is not None else None
@@ -119,6 +134,18 @@ def generate_root_provenance_manifest(
                 )
             )
 
+    if source_completeness_root is not None:
+        for path in _iter_files(source_completeness_root):
+            artifacts["source_completeness"].append(
+                _artifact_record(
+                    _artifact_id_from_path(path),
+                    path,
+                    root_dir=root_dir,
+                    source_root=source_completeness_root,
+                    declared_in="source_completeness_dir",
+                )
+            )
+
     if package_manifest is not None:
         artifacts["package"].append(
             _artifact_record(
@@ -162,6 +189,8 @@ def generate_root_provenance_manifest(
     }
     if candidate_root is not None:
         manifest["roots"]["candidate_library_dir"] = _display_path(candidate_root, root_dir)
+    if source_completeness_root is not None:
+        manifest["roots"]["source_completeness_dir"] = _display_path(source_completeness_root, root_dir)
     if package_manifest is not None:
         manifest["source_manifests"]["package_manifest_json"] = _file_facts(package_manifest, root_dir=root_dir)
 
@@ -178,6 +207,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--report-dir", required=True)
     parser.add_argument("--si-dir", required=True)
     parser.add_argument("--candidate-library-dir")
+    parser.add_argument("--source-completeness-dir")
     parser.add_argument("--package-manifest-path")
     parser.add_argument("--input-path")
     parser.add_argument("--candidate-source-path")
@@ -188,6 +218,7 @@ def main(argv: list[str] | None = None) -> int:
         args.report_dir,
         args.si_dir,
         candidate_library_dir=args.candidate_library_dir,
+        source_completeness_dir=args.source_completeness_dir,
         package_manifest_path=args.package_manifest_path,
         input_path=args.input_path,
         candidate_source_path=args.candidate_source_path,

--- a/hybrid_agent_exploration/src/reporting/si_generator.py
+++ b/hybrid_agent_exploration/src/reporting/si_generator.py
@@ -13,6 +13,8 @@ import numpy as np
 
 warnings.filterwarnings("ignore")
 
+from data.source_completeness import format_source_completeness_markdown
+
 from .figure_generator import FigureGenerator
 from .figure_selector import FigureSelector
 from .image_embedder import embed_markdown_images
@@ -42,6 +44,7 @@ class SIGenerator:
         self.shap = SHAPAnalyzer(self.fig_dir)
         self.mol = MolecularPlotter(self.fig_dir)
         self.verified_discovery = load_verified_discovery_summary(self.artifacts)
+        self.source_completeness = self._source_completeness()
 
     def generate(self) -> Path:
         """Generate the complete SI document."""
@@ -52,6 +55,10 @@ class SIGenerator:
         if evidence_note:
             lines.append("## S0. Evidence Context")
             lines.append(evidence_note)
+            lines.append("")
+        if self.source_completeness:
+            lines.append("## S0b. Source Completeness Audit")
+            lines.append(format_source_completeness_markdown(self.source_completeness))
             lines.append("")
 
         lines.append("## S1. Data Cleaning and Quality Control")
@@ -423,6 +430,10 @@ class SIGenerator:
 
     def _evidence_context(self) -> dict[str, Any]:
         value = self.artifacts.get("evidence_context")
+        return value if isinstance(value, dict) else {}
+
+    def _source_completeness(self) -> dict[str, Any]:
+        value = self.artifacts.get("source_completeness")
         return value if isinstance(value, dict) else {}
 
     def _has_training_only_metrics(self) -> bool:

--- a/hybrid_agent_exploration/src/reporting/top_journal_report.py
+++ b/hybrid_agent_exploration/src/reporting/top_journal_report.py
@@ -19,6 +19,8 @@ import numpy as np
 
 warnings.filterwarnings("ignore")
 
+from data.source_completeness import format_source_completeness_markdown
+
 from .composite_figure import CompositeFigure, CompositeFigureTemplates
 from .figure_selector import FigureSelector
 from .image_embedder import embed_markdown_images
@@ -59,6 +61,7 @@ class TopJournalReport:
         self.selector = FigureSelector(self.artifacts)
         self.narrative = NarrativeEngine()
         self.verified_discovery = load_verified_discovery_summary(self.artifacts)
+        self.source_completeness = self._source_completeness()
 
     def generate(self) -> ReportBundle:
         """Generate the complete main-text report."""
@@ -688,6 +691,12 @@ class TopJournalReport:
                 format_verified_discovery_markdown(self.verified_discovery),
                 "",
             ])
+        if self.source_completeness:
+            lines.extend([
+                "### Source Completeness Audit",
+                format_source_completeness_markdown(self.source_completeness),
+                "",
+            ])
 
         lines.extend([
             "## 4. Limitations and Evidence Gaps",
@@ -933,6 +942,13 @@ class TopJournalReport:
                     "source": "dataset/quarantine.csv",
                 },
             ])
+        if self.source_completeness:
+            ledger.append({
+                "claim": "Source completeness audit is column-level missingness only and not external verification",
+                "evidence_id": "provenance:source_completeness.input_table",
+                "value": self.source_completeness,
+                "source": "source_completeness/source_completeness.json",
+            })
         evidence_context = self._evidence_context()
         if evidence_context:
             ledger.append({
@@ -987,6 +1003,8 @@ class TopJournalReport:
             manifest["agents"].insert(0, "PlanRegistryAgent")
         if self.verified_discovery:
             manifest["verified_discovery"] = self.verified_discovery
+        if self.source_completeness:
+            manifest["source_completeness"] = self.source_completeness
         evidence_context = self._evidence_context()
         if evidence_context:
             manifest["evidence_context"] = evidence_context
@@ -1061,6 +1079,10 @@ class TopJournalReport:
 
     def _evidence_context(self) -> dict[str, Any]:
         value = self.artifacts.get("evidence_context")
+        return value if isinstance(value, dict) else {}
+
+    def _source_completeness(self) -> dict[str, Any]:
+        value = self.artifacts.get("source_completeness")
         return value if isinstance(value, dict) else {}
 
     def _is_source_columns_smoke(self) -> bool:

--- a/hybrid_agent_exploration/src/run_research_package.py
+++ b/hybrid_agent_exploration/src/run_research_package.py
@@ -76,6 +76,7 @@ def run_research_package(
             df,
             dataset_id=dataset_id,
             source_name=Path(input_path).stem,
+            max_rows=max_rows,
         ),
         output_root / "source_completeness",
     )

--- a/hybrid_agent_exploration/src/run_research_package.py
+++ b/hybrid_agent_exploration/src/run_research_package.py
@@ -15,6 +15,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from data.source_completeness import (
+    summarize_source_completeness,
+    write_source_completeness_artifacts,
+)
 from reporting.root_provenance_manifest import generate_root_provenance_manifest
 from reporting.si_generator import SIGenerator
 from reporting.top_journal_report import TopJournalReport
@@ -37,6 +41,7 @@ class ResearchPackageArtifacts:
 
     output_dir: Path
     verified_discovery_dir: Path
+    source_completeness_dir: Path
     candidate_library_dir: Path | None
     report_dir: Path
     root_provenance_manifest_json: Path
@@ -66,6 +71,14 @@ def run_research_package(
     report_dir = output_root / "report_bundle"
 
     df = load_input(input_path, max_rows=max_rows)
+    source_completeness_artifacts = write_source_completeness_artifacts(
+        summarize_source_completeness(
+            df,
+            dataset_id=dataset_id,
+            source_name=Path(input_path).stem,
+        ),
+        output_root / "source_completeness",
+    )
     cache_root = Path(cache_dir) if cache_dir else default_cache_dir(dataset_id)
     authenticator = build_authenticator(evidence_mode, df, cache_root)
 
@@ -119,6 +132,7 @@ def run_research_package(
     report_inputs = _report_inputs(
         verified_discovery_dir,
         top_n=verified_discovery_top_n or top_k,
+        source_completeness=source_completeness_artifacts.summary,
         evidence_context={
             "evidence_mode": evidence_mode,
             "verification_level": verification_level,
@@ -163,6 +177,7 @@ def run_research_package(
             report_quality_target=report_quality_target,
             verified_discovery_top_n=verified_discovery_top_n,
             discovery_artifacts=discovery_artifacts,
+            source_completeness_dir=source_completeness_artifacts.output_dir,
             candidate_library_dir=candidate_library_dir,
             candidate_library_rows=candidate_library_rows,
             report_dir=report_dir,
@@ -179,6 +194,7 @@ def run_research_package(
         main_bundle.path.parent,
         si_path.parent,
         candidate_library_dir=candidate_library_dir,
+        source_completeness_dir=source_completeness_artifacts.output_dir,
         package_manifest_path=package_manifest_path,
         input_path=input_path,
         candidate_source_path=candidate_source_path,
@@ -187,6 +203,7 @@ def run_research_package(
     return ResearchPackageArtifacts(
         output_dir=output_root,
         verified_discovery_dir=verified_discovery_dir,
+        source_completeness_dir=source_completeness_artifacts.output_dir,
         candidate_library_dir=candidate_library_dir,
         report_dir=report_dir,
         root_provenance_manifest_json=root_manifest_path,
@@ -198,6 +215,7 @@ def _report_inputs(
     verified_discovery_dir: Path,
     *,
     top_n: int,
+    source_completeness: dict[str, Any],
     evidence_context: dict[str, Any],
 ) -> dict[str, Any]:
     metrics = _read_json(verified_discovery_dir / "model" / "model_metrics.json")
@@ -230,6 +248,7 @@ def _report_inputs(
     artifacts = {
         "verified_discovery_artifact_dir": verified_discovery_dir,
         "verified_discovery_top_n": top_n,
+        "source_completeness": source_completeness,
         "evidence_context": evidence_context,
         "multi_model_results": [
             {
@@ -264,6 +283,7 @@ def _package_manifest(
     report_quality_target: str,
     verified_discovery_top_n: int | None,
     discovery_artifacts,
+    source_completeness_dir: Path,
     candidate_library_dir: Path | None,
     candidate_library_rows: int | None,
     report_dir: Path,
@@ -323,6 +343,10 @@ def _package_manifest(
         "report_quality_score": report_quality_score,
         "outputs": {
             "verified_discovery_dir": _relative(discovery_artifacts.output_dir, output_root),
+            "source_completeness_dir": _relative(source_completeness_dir, output_root),
+            "source_completeness_json": _relative(source_completeness_dir / "source_completeness.json", output_root),
+            "source_completeness_csv": _relative(source_completeness_dir / "source_completeness.csv", output_root),
+            "source_completeness_md": _relative(source_completeness_dir / "source_completeness.md", output_root),
             "candidate_library_dir": _relative(candidate_library_dir, output_root) if candidate_library_dir else None,
             "report_dir": _relative(report_dir, output_root),
             "main_text_report_md": _relative(report_dir / "main_text" / "main_text_report.md", output_root),

--- a/tests/test_research_package_runner.py
+++ b/tests/test_research_package_runner.py
@@ -193,6 +193,8 @@ def test_research_package_runner_generates_all_scientific_artifacts(tmp_path):
     )
     assert source_completeness["row_count"] == 5
     assert source_completeness["external_verification"] is False
+    assert source_completeness["max_rows"] is None
+    assert source_completeness["max_rows_is_smoke_only"] is False
 
     si_text = (package.report_dir / "si" / "supporting_information.md").read_text(encoding="utf-8")
     assert "source-columns" in si_text
@@ -331,3 +333,19 @@ def test_external_cached_max_rows_does_not_overclaim_publication_grade(tmp_path,
     assert run_manifest["evidence_context"]["max_rows_is_smoke_only"] is True
     assert run_manifest["evidence_context"]["dataset_publication_grade"] is False
     assert run_manifest["evidence_context"]["publication_grade"] is False
+    assert run_manifest["source_completeness"]["max_rows"] == 4
+    assert run_manifest["source_completeness"]["max_rows_is_smoke_only"] is True
+    assert run_manifest["source_completeness"]["audit_population"] == "max_rows_subset"
+
+    source_completeness = json.loads(
+        (package.output_dir / "source_completeness" / "source_completeness.json").read_text(encoding="utf-8")
+    )
+    assert source_completeness["max_rows"] == 4
+    assert source_completeness["max_rows_is_smoke_only"] is True
+    assert source_completeness["audit_population"] == "max_rows_subset"
+
+    source_completeness_md = (
+        package.output_dir / "source_completeness" / "source_completeness.md"
+    ).read_text(encoding="utf-8")
+    assert "smoke-only subset" in source_completeness_md
+    assert "not a full-source audit" in source_completeness_md

--- a/tests/test_research_package_runner.py
+++ b/tests/test_research_package_runner.py
@@ -99,6 +99,9 @@ def test_research_package_runner_generates_all_scientific_artifacts(tmp_path):
         package.report_dir / "main_text" / "review_report.json",
         package.report_dir / "main_text" / "run_manifest.json",
         package.report_dir / "si" / "supporting_information.md",
+        package.output_dir / "source_completeness" / "source_completeness.json",
+        package.output_dir / "source_completeness" / "source_completeness.csv",
+        package.output_dir / "source_completeness" / "source_completeness.md",
         package.root_provenance_manifest_json,
         package.package_manifest_json,
     ]
@@ -132,6 +135,10 @@ def test_research_package_runner_generates_all_scientific_artifacts(tmp_path):
     assert package_manifest["inputs"]["candidate_source"]["source_name"] == "fixture-vendor-source"
     assert package_manifest["inputs"]["candidate_source"]["exists"] is True
     assert len(package_manifest["inputs"]["candidate_source"]["sha256"]) == 64
+    assert package_manifest["outputs"]["source_completeness_dir"] == "source_completeness"
+    assert package_manifest["outputs"]["source_completeness_json"] == "source_completeness/source_completeness.json"
+    assert package_manifest["outputs"]["source_completeness_csv"] == "source_completeness/source_completeness.csv"
+    assert package_manifest["outputs"]["source_completeness_md"] == "source_completeness/source_completeness.md"
     assert package_manifest["outputs"]["root_provenance_manifest_json"] == "provenance_manifest.json"
 
     workflow_manifest = json.loads(
@@ -178,13 +185,27 @@ def test_research_package_runner_generates_all_scientific_artifacts(tmp_path):
     assert run_manifest["evidence_context"]["source_columns_is_smoke_only"] is True
     assert run_manifest["evidence_context"]["metric_scope"] == "training_only"
     assert run_manifest["evidence_context"]["candidate_library_publication_grade"] is False
+    assert run_manifest["source_completeness"]["audit_scope"] == "column_level_missingness_only"
+    assert run_manifest["source_completeness"]["external_verification"] is False
+
+    source_completeness = json.loads(
+        (package.output_dir / "source_completeness" / "source_completeness.json").read_text(encoding="utf-8")
+    )
+    assert source_completeness["row_count"] == 5
+    assert source_completeness["external_verification"] is False
 
     si_text = (package.report_dir / "si" / "supporting_information.md").read_text(encoding="utf-8")
     assert "source-columns" in si_text
     assert "smoke-only" in si_text
     assert "training-only" in si_text
     assert "Candidate-library publication-grade flag: `False`" in si_text
+    assert "Source Completeness Audit" in si_text
+    assert "column-level missingness audit" in si_text
     assert "Cross-validation was not supplied" in si_text
+
+    report_text = (package.report_dir / "main_text" / "main_text_report.md").read_text(encoding="utf-8")
+    assert "Source Completeness Audit" in report_text
+    assert "not external verification" in report_text
 
     root_manifest = json.loads(package.root_provenance_manifest_json.read_text(encoding="utf-8"))
     assert root_manifest["dataset_id"] == "package-fixture"
@@ -196,6 +217,11 @@ def test_research_package_runner_generates_all_scientific_artifacts(tmp_path):
     assert len(root_manifest["source_inputs"]["input_table"]["sha256"]) == 64
     assert root_manifest["source_inputs"]["candidate_source_table"]["path"].endswith("candidate_source.csv")
     assert len(root_manifest["source_inputs"]["candidate_source_table"]["sha256"]) == 64
+    assert {item["id"] for item in root_manifest["artifacts"]["source_completeness"]} == {
+        "source_completeness_csv",
+        "source_completeness_json",
+        "source_completeness_md",
+    }
     assert "candidate_library:candidate_library_csv" in {
         item["id"] for item in root_manifest["artifacts"]["discovery"]
     }

--- a/tests/test_root_provenance_manifest.py
+++ b/tests/test_root_provenance_manifest.py
@@ -47,6 +47,10 @@ def test_root_provenance_manifest_indexes_verified_discovery_report_and_si(tmp_p
     _write(candidate_library_dir / "candidate_library.csv", "candidate_id,smiles\ncand-001,C\n")
     _write(candidate_library_dir / "source_summary.json", '{"output_rows": 1}\n')
     _write(candidate_library_dir / "provenance.json", '{"network_access": "not_used"}\n')
+    source_completeness_dir = tmp_path / "source_completeness"
+    _write(source_completeness_dir / "source_completeness.json", '{"audit_scope": "column_level_missingness_only"}\n')
+    _write(source_completeness_dir / "source_completeness.csv", "group_id,column,present\nliterature_metadata,doi,true\n")
+    _write(source_completeness_dir / "source_completeness.md", "# Source Completeness Audit\n")
     package_manifest = _write(
         tmp_path / "package_manifest.json",
         '{"schema_version": "research-package-manifest-v1"}\n',
@@ -57,6 +61,7 @@ def test_root_provenance_manifest_indexes_verified_discovery_report_and_si(tmp_p
         report_dir,
         si_dir,
         candidate_library_dir=candidate_library_dir,
+        source_completeness_dir=source_completeness_dir,
         package_manifest_path=package_manifest,
         input_path=input_table,
         candidate_source_path=candidate_source,
@@ -87,6 +92,11 @@ def test_root_provenance_manifest_indexes_verified_discovery_report_and_si(tmp_p
     assert {item["id"] for item in manifest["artifacts"]["claim"]} == {"claim_ledger_json"}
     assert {item["id"] for item in manifest["artifacts"]["review"]} == {"review_report_json"}
     assert {item["id"] for item in manifest["artifacts"]["package"]} == {"package_manifest_json"}
+    assert {item["id"] for item in manifest["artifacts"]["source_completeness"]} == {
+        "source_completeness_csv",
+        "source_completeness_json",
+        "source_completeness_md",
+    }
     assert manifest["source_manifests"]["package_manifest_json"]["exists"] is True
     assert manifest["source_inputs"]["input_table"]["path"].endswith("raw_source.csv")
     assert len(manifest["source_inputs"]["input_table"]["sha256"]) == 64
@@ -98,6 +108,7 @@ def test_root_provenance_manifest_indexes_verified_discovery_report_and_si(tmp_p
     assert verified_train["size_bytes"] == len("record_id,smiles\nrow-001,C\n")
     assert verified_train["sha256_16"]
     assert manifest["roots"]["candidate_library_dir"] == str(candidate_library_dir)
+    assert manifest["roots"]["source_completeness_dir"] == str(source_completeness_dir)
 
 
 def test_root_provenance_manifest_records_missing_declared_outputs(tmp_path):

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -1,0 +1,140 @@
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1] / "hybrid_agent_exploration"
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+
+def _source_frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "title": "Verified additive record A",
+                "authors": "A. Example",
+                "journal": "Journal of Physical Chemistry Letters",
+                "doi": "10.1021/acs.jpclett.6c00119",
+                "abstract": "Perovskite additive study.",
+                "smiles": "CCO",
+                "pubchem_id": "702",
+                "cas_number": "64-17-5",
+                "molecular_formula": "C2H6O",
+                "molecular_weight": 46.07,
+                "h_bond_donors": 1,
+                "h_bond_acceptors": 1,
+                "rotatable_bonds": 0,
+                "tpsa": 20.23,
+                "log_p": -0.31,
+                "jv_reverse_scan_pce_without_modulator": 18.0,
+                "jv_reverse_scan_pce": 18.5,
+                "delta_pce": 0.5,
+            },
+            {
+                "title": "Verified additive record B",
+                "authors": "B. Example",
+                "journal": "",
+                "doi": "10.1021/acs.jpclett.6c00120",
+                "abstract": None,
+                "smiles": "CCN",
+                "pubchem_id": "8471",
+                "cas_number": "",
+                "molecular_formula": "C6H15N",
+                "molecular_weight": 101.19,
+                "h_bond_donors": 0,
+                "h_bond_acceptors": 1,
+                "rotatable_bonds": 3,
+                "tpsa": 3.24,
+                "log_p": 1.44,
+                "jv_reverse_scan_pce_without_modulator": 17.0,
+                "jv_reverse_scan_pce": 17.2,
+                "delta_pce": 0.2,
+            },
+            {
+                "title": "",
+                "authors": "",
+                "journal": "Advanced Energy Materials",
+                "doi": "",
+                "abstract": "Missing DOI but has chemistry.",
+                "smiles": "CCCC",
+                "pubchem_id": "7843",
+                "cas_number": "106-97-8",
+                "molecular_formula": "C4H10",
+                "molecular_weight": 58.12,
+                "h_bond_donors": 0,
+                "h_bond_acceptors": 0,
+                "rotatable_bonds": 1,
+                "tpsa": 0.0,
+                "log_p": 2.89,
+                "jv_reverse_scan_pce_without_modulator": None,
+                "jv_reverse_scan_pce": 16.1,
+                "delta_pce": None,
+            },
+        ]
+    )
+
+
+def test_source_completeness_uses_real_psc_source_columns_and_writes_json_markdown_csv(tmp_path):
+    from data.source_completeness import (
+        SOURCE_COMPLETENESS_SCHEMA_VERSION,
+        summarize_source_completeness,
+        write_source_completeness_artifacts,
+    )
+
+    summary = summarize_source_completeness(
+        _source_frame(),
+        dataset_id="psc-source-fixture",
+        source_name="source-columns-smoke",
+    )
+    artifacts = write_source_completeness_artifacts(summary, tmp_path / "source_completeness")
+
+    assert artifacts.summary_json.exists()
+    assert artifacts.table_csv.exists()
+    assert artifacts.markdown.exists()
+
+    payload = json.loads(artifacts.summary_json.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == SOURCE_COMPLETENESS_SCHEMA_VERSION
+    assert payload["dataset_id"] == "psc-source-fixture"
+    assert payload["row_count"] == 3
+    assert payload["audit_scope"] == "column_level_missingness_only"
+    assert payload["external_verification"] is False
+
+    groups = {group["id"]: group for group in payload["groups"]}
+    assert {"literature_metadata", "chemical_identity", "molecular_descriptors", "jv_core", "target_derivation"}.issubset(groups)
+
+    literature_columns = {column["column"]: column for column in groups["literature_metadata"]["columns"]}
+    assert literature_columns["doi"]["non_missing"] == 2
+    assert literature_columns["doi"]["missing"] == 1
+    assert literature_columns["doi"]["completeness_fraction"] == 0.666667
+    assert literature_columns["abstract"]["missing"] == 1
+
+    identity_columns = {column["column"]: column for column in groups["chemical_identity"]["columns"]}
+    assert identity_columns["smiles"]["completeness_fraction"] == 1.0
+    assert identity_columns["cas_number"]["missing"] == 1
+
+    markdown = artifacts.markdown.read_text(encoding="utf-8")
+    assert "Source Completeness Audit" in markdown
+    assert "column-level missingness audit" in markdown
+    assert "not external verification" in markdown
+    assert "| literature_metadata | doi | yes | 2 | 1 | 0.666667 |" in markdown
+
+    table = pd.read_csv(artifacts.table_csv)
+    assert {"group_id", "column", "present", "non_missing", "missing", "completeness_fraction"}.issubset(table.columns)
+    assert "doi" in table["column"].tolist()
+
+
+def test_source_completeness_does_not_fabricate_absent_pdf_source_columns(tmp_path):
+    from data.source_completeness import format_source_completeness_markdown, summarize_source_completeness
+
+    summary = summarize_source_completeness(
+        _source_frame(),
+        dataset_id="psc-source-fixture",
+        source_name="source-columns-smoke",
+    )
+    markdown = format_source_completeness_markdown(summary)
+    serialized = json.dumps(summary, sort_keys=True) + markdown
+
+    assert "source_pdf_path" not in serialized
+    assert "pdf" not in {group["id"] for group in summary["groups"]}

--- a/tests/test_source_completeness.py
+++ b/tests/test_source_completeness.py
@@ -100,6 +100,9 @@ def test_source_completeness_uses_real_psc_source_columns_and_writes_json_markdo
     assert payload["row_count"] == 3
     assert payload["audit_scope"] == "column_level_missingness_only"
     assert payload["external_verification"] is False
+    assert payload["max_rows"] is None
+    assert payload["max_rows_is_smoke_only"] is False
+    assert payload["audit_population"] == "loaded_source_table"
 
     groups = {group["id"]: group for group in payload["groups"]}
     assert {"literature_metadata", "chemical_identity", "molecular_descriptors", "jv_core", "target_derivation"}.issubset(groups)
@@ -138,3 +141,23 @@ def test_source_completeness_does_not_fabricate_absent_pdf_source_columns(tmp_pa
 
     assert "source_pdf_path" not in serialized
     assert "pdf" not in {group["id"] for group in summary["groups"]}
+
+
+def test_source_completeness_marks_max_rows_subset_as_smoke_only():
+    from data.source_completeness import format_source_completeness_markdown, summarize_source_completeness
+
+    summary = summarize_source_completeness(
+        _source_frame().head(2),
+        dataset_id="psc-source-fixture",
+        source_name="source-columns-smoke",
+        max_rows=2,
+    )
+
+    assert summary["row_count"] == 2
+    assert summary["max_rows"] == 2
+    assert summary["max_rows_is_smoke_only"] is True
+    assert summary["audit_population"] == "max_rows_subset"
+
+    markdown = format_source_completeness_markdown(summary)
+    assert "smoke-only subset" in markdown
+    assert "not a full-source audit" in markdown


### PR DESCRIPTION
## Summary
- add source-completeness JSON/CSV/Markdown artifacts for column-level missingness audits of PSC source tables
- integrate the audit into research package manifests, root provenance, main text, and SI
- keep wording explicit that completeness is not external DOI/molecule/supplier verification

## Verification
- .......................                                                  [100%]
23 passed in 9.61s
- 
- real 500-row source-columns package run without offline candidate-source: source completeness artifacts generated and indexed; package remained smoke-only and non-publication-grade