### PR TITLE
fix: contextualize external-cached smoke conclusions

### DIFF
--- a/hybrid_agent_exploration/src/reporting/top_journal_report.py
+++ b/hybrid_agent_exploration/src/reporting/top_journal_report.py
@@ -872,8 +872,30 @@ class TopJournalReport:
                 "",
                 "This research package demonstrates that the verified-discovery artifact chain can produce a traceable dataset, candidate library, ranked candidates, manuscript text, SI, and provenance manifests from real input records.",
                 f"{metric_sentence} {smoke_sentence}The package does not support claims about representation superiority, baseline-feature benefit, SHAP-derived mechanisms, scaffold generalization, or externally validated candidate performance unless those artifacts are added in a future run.",
-                "The next scientific step is to replace smoke evidence with external-cached DOI and molecule verification, add held-out validation protocols, and connect top candidates to independently verifiable experimental or supplier evidence.",
+                self._next_scientific_step(),
             ]
+        )
+
+    def _next_scientific_step(self) -> str:
+        context = self._evidence_context()
+        if self._is_source_columns_smoke():
+            return (
+                "The next scientific step is to replace source-columns smoke evidence with external-cached DOI and molecule verification, "
+                "add held-out validation protocols, and connect top candidates to independently verifiable experimental or supplier evidence."
+            )
+        if context.get("max_rows_is_smoke_only"):
+            return (
+                "The next scientific step is to rerun the external-cached workflow without `max_rows`, add held-out validation protocols, "
+                "and connect top candidates to independently verifiable experimental or supplier evidence."
+            )
+        if context.get("evidence_mode") == "external-cached":
+            return (
+                "The next scientific step is to add held-out validation protocols and connect top candidates to independently verifiable "
+                "experimental or supplier evidence."
+            )
+        return (
+            "The next scientific step is to strengthen evidence verification, add held-out validation protocols, and connect top candidates "
+            "to independently verifiable experimental or supplier evidence."
         )
 
     def _build_claim_ledger(self, figure_paths: list[tuple[str, Path]], best_result: dict | None) -> list[dict[str, Any]]:

--- a/tests/test_research_package_runner.py
+++ b/tests/test_research_package_runner.py
@@ -337,6 +337,10 @@ def test_external_cached_max_rows_does_not_overclaim_publication_grade(tmp_path,
     assert run_manifest["source_completeness"]["max_rows_is_smoke_only"] is True
     assert run_manifest["source_completeness"]["audit_population"] == "max_rows_subset"
 
+    report_text = (package.report_dir / "main_text" / "main_text_report.md").read_text(encoding="utf-8")
+    assert "replace smoke evidence with external-cached" not in report_text
+    assert "rerun the external-cached workflow without `max_rows`" in report_text
+
     source_completeness = json.loads(
         (package.output_dir / "source_completeness" / "source_completeness.json").read_text(encoding="utf-8")
     )


### PR DESCRIPTION
## Summary
- make training-only conclusions distinguish source-columns smoke runs, external-cached capped smoke runs, and full external-cached runs
- prevent capped external-cached packages from saying the next step is to replace smoke evidence with external-cached verification
- add regression coverage for external-cached max_rows report wording

## Verification
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_research_package_runner.py tests/test_top_journal_reporting.py tests/test_source_completeness.py tests/test_root_provenance_manifest.py
- python -m py_compile hybrid_agent_exploration/src/reporting/top_journal_report.py && git diff --check
- real external-cached 20-row smoke: 5 verified / 15 quarantined, package remained non-publication-grade and source completeness was marked max_rows_subset