### PR TITLE
fix: gate publication grade on input scope

### DIFF
--- a/hybrid_agent_exploration/src/run_research_package.py
+++ b/hybrid_agent_exploration/src/run_research_package.py
@@ -22,7 +22,7 @@ from data.source_completeness import (
 from reporting.root_provenance_manifest import generate_root_provenance_manifest
 from reporting.si_generator import SIGenerator
 from reporting.top_journal_report import TopJournalReport
-from run_verified_discovery import build_authenticator, default_cache_dir, load_input
+from run_verified_discovery import build_authenticator, default_cache_dir, load_input, publication_grade_gate
 from screening.candidate_library_builder import CandidateLibraryBuilder
 from screening.verified_candidate_discovery import CANDIDATE_LIBRARY_CONTRACT_VERSION
 from screening.verified_discovery_workflow import VerifiedDiscoveryWorkflow
@@ -58,6 +58,7 @@ def run_research_package(
     candidate_source_name: str | None = None,
     cache_dir: str | Path | None = None,
     max_rows: int | None = None,
+    input_scope: str = "selected-subset",
     min_verified_rows: int = 10,
     top_k: int = 100,
     report_quality_target: str = "top-journal",
@@ -98,18 +99,32 @@ def run_research_package(
         candidate_library_rows = candidate_artifacts.output_count
 
     verification_level = _verification_level(evidence_mode)
-    dataset_publication_grade = evidence_mode == "external-cached" and max_rows is None
+    dataset_publication_grade, dataset_publication_grade_reason = publication_grade_gate(
+        evidence_mode=evidence_mode,
+        input_scope=input_scope,
+        max_rows=max_rows,
+    )
     candidate_library_publication_grade = candidate_source_path is None
     publication_grade = dataset_publication_grade and candidate_library_publication_grade
+    publication_grade_reason = _publication_grade_reason(
+        publication_grade=publication_grade,
+        dataset_publication_grade=dataset_publication_grade,
+        dataset_publication_grade_reason=dataset_publication_grade_reason,
+        candidate_library_publication_grade=candidate_library_publication_grade,
+    )
     run_metadata = {
         "evidence_mode": evidence_mode,
         "verification_level": verification_level,
         "publication_grade": publication_grade,
+        "publication_grade_reason": publication_grade_reason,
         "dataset_publication_grade": dataset_publication_grade,
+        "dataset_publication_grade_reason": dataset_publication_grade_reason,
         "candidate_library_publication_grade": candidate_library_publication_grade,
+        "input_scope": input_scope,
         "source_columns_is_smoke_only": evidence_mode == "source-columns",
         "input_path": str(Path(input_path)),
         "max_rows": max_rows,
+        "max_rows_is_smoke_only": max_rows is not None,
         "candidate_pool_contract_version": CANDIDATE_LIBRARY_CONTRACT_VERSION,
         "research_package_runner": "run_research_package",
     }
@@ -138,8 +153,11 @@ def run_research_package(
             "evidence_mode": evidence_mode,
             "verification_level": verification_level,
             "publication_grade": publication_grade,
+            "publication_grade_reason": publication_grade_reason,
             "dataset_publication_grade": dataset_publication_grade,
+            "dataset_publication_grade_reason": dataset_publication_grade_reason,
             "candidate_library_publication_grade": candidate_library_publication_grade,
+            "input_scope": input_scope,
             "source_columns_is_smoke_only": evidence_mode == "source-columns",
             "max_rows": max_rows,
             "max_rows_is_smoke_only": max_rows is not None,
@@ -167,8 +185,11 @@ def run_research_package(
             output_root=output_root,
             evidence_mode=evidence_mode,
             dataset_publication_grade=dataset_publication_grade,
+            dataset_publication_grade_reason=dataset_publication_grade_reason,
             candidate_library_publication_grade=candidate_library_publication_grade,
             publication_grade=publication_grade,
+            publication_grade_reason=publication_grade_reason,
+            input_scope=input_scope,
             input_path=Path(input_path),
             candidate_source_path=Path(candidate_source_path) if candidate_source_path is not None else None,
             candidate_source_name=candidate_source_name,
@@ -273,8 +294,11 @@ def _package_manifest(
     output_root: Path,
     evidence_mode: str,
     dataset_publication_grade: bool,
+    dataset_publication_grade_reason: str,
     candidate_library_publication_grade: bool,
     publication_grade: bool,
+    publication_grade_reason: str,
+    input_scope: str,
     input_path: Path,
     candidate_source_path: Path | None,
     candidate_source_name: str | None,
@@ -304,6 +328,7 @@ def _package_manifest(
         "candidate_source_name": candidate_source_name,
         "cache_dir": str(cache_dir) if cache_dir is not None else None,
         "max_rows": max_rows,
+        "input_scope": input_scope,
         "min_verified_rows": min_verified_rows,
         "top_k": top_k,
         "report_quality_target": report_quality_target,
@@ -331,8 +356,11 @@ def _package_manifest(
         "evidence_mode": evidence_mode,
         "verification_level": verification_level,
         "publication_grade": publication_grade,
+        "publication_grade_reason": publication_grade_reason,
         "dataset_publication_grade": dataset_publication_grade,
+        "dataset_publication_grade_reason": dataset_publication_grade_reason,
         "candidate_library_publication_grade": candidate_library_publication_grade,
+        "input_scope": input_scope,
         "source_columns_is_smoke_only": evidence_mode == "source-columns",
         "max_rows": max_rows,
         "max_rows_is_smoke_only": max_rows is not None,
@@ -401,6 +429,22 @@ def _verification_level(evidence_mode: str) -> str:
     return "external_cached" if evidence_mode == "external-cached" else "source_columns_only"
 
 
+def _publication_grade_reason(
+    *,
+    publication_grade: bool,
+    dataset_publication_grade: bool,
+    dataset_publication_grade_reason: str,
+    candidate_library_publication_grade: bool,
+) -> str:
+    if publication_grade:
+        return "all publication-grade gates passed"
+    if not dataset_publication_grade:
+        return dataset_publication_grade_reason
+    if not candidate_library_publication_grade:
+        return "candidate library is offline-normalized"
+    return "publication-grade gates failed"
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--input", required=True, help="CSV/XLSX PSC source table.")
@@ -411,6 +455,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--candidate-source-name", help="Source name for candidate-source normalization.")
     parser.add_argument("--cache-dir", help="External evidence cache directory.")
     parser.add_argument("--max-rows", type=int, help="Optional row cap for smoke runs.")
+    parser.add_argument(
+        "--input-scope",
+        choices=("selected-subset", "full-source"),
+        default="selected-subset",
+        help="Declare whether the input is the full source table or a selected subset.",
+    )
     parser.add_argument("--min-verified-rows", type=int, default=10)
     parser.add_argument("--top-k", type=int, default=100)
     parser.add_argument("--report-quality-target", choices=("standard", "top-journal"), default="top-journal")
@@ -428,6 +478,7 @@ def main(argv: list[str] | None = None) -> int:
         candidate_source_name=args.candidate_source_name,
         cache_dir=args.cache_dir,
         max_rows=args.max_rows,
+        input_scope=args.input_scope,
         min_verified_rows=args.min_verified_rows,
         top_k=args.top_k,
         report_quality_target=args.report_quality_target,

--- a/hybrid_agent_exploration/src/run_research_package.py
+++ b/hybrid_agent_exploration/src/run_research_package.py
@@ -105,21 +105,30 @@ def run_research_package(
         max_rows=max_rows,
     )
     candidate_library_publication_grade = candidate_source_path is None
+    candidate_library_publication_grade_reason = (
+        "no offline candidate source" if candidate_library_publication_grade else "candidate library is offline-normalized"
+    )
     publication_grade = dataset_publication_grade and candidate_library_publication_grade
-    publication_grade_reason = _publication_grade_reason(
-        publication_grade=publication_grade,
+    publication_grade_reasons = _publication_grade_reasons(
         dataset_publication_grade=dataset_publication_grade,
         dataset_publication_grade_reason=dataset_publication_grade_reason,
         candidate_library_publication_grade=candidate_library_publication_grade,
+        candidate_library_publication_grade_reason=candidate_library_publication_grade_reason,
+    )
+    publication_grade_reason = _publication_grade_reason(
+        publication_grade=publication_grade,
+        publication_grade_reasons=publication_grade_reasons,
     )
     run_metadata = {
         "evidence_mode": evidence_mode,
         "verification_level": verification_level,
         "publication_grade": publication_grade,
         "publication_grade_reason": publication_grade_reason,
+        "publication_grade_reasons": publication_grade_reasons,
         "dataset_publication_grade": dataset_publication_grade,
         "dataset_publication_grade_reason": dataset_publication_grade_reason,
         "candidate_library_publication_grade": candidate_library_publication_grade,
+        "candidate_library_publication_grade_reason": candidate_library_publication_grade_reason,
         "input_scope": input_scope,
         "source_columns_is_smoke_only": evidence_mode == "source-columns",
         "input_path": str(Path(input_path)),
@@ -154,9 +163,11 @@ def run_research_package(
             "verification_level": verification_level,
             "publication_grade": publication_grade,
             "publication_grade_reason": publication_grade_reason,
+            "publication_grade_reasons": publication_grade_reasons,
             "dataset_publication_grade": dataset_publication_grade,
             "dataset_publication_grade_reason": dataset_publication_grade_reason,
             "candidate_library_publication_grade": candidate_library_publication_grade,
+            "candidate_library_publication_grade_reason": candidate_library_publication_grade_reason,
             "input_scope": input_scope,
             "source_columns_is_smoke_only": evidence_mode == "source-columns",
             "max_rows": max_rows,
@@ -187,8 +198,10 @@ def run_research_package(
             dataset_publication_grade=dataset_publication_grade,
             dataset_publication_grade_reason=dataset_publication_grade_reason,
             candidate_library_publication_grade=candidate_library_publication_grade,
+            candidate_library_publication_grade_reason=candidate_library_publication_grade_reason,
             publication_grade=publication_grade,
             publication_grade_reason=publication_grade_reason,
+            publication_grade_reasons=publication_grade_reasons,
             input_scope=input_scope,
             input_path=Path(input_path),
             candidate_source_path=Path(candidate_source_path) if candidate_source_path is not None else None,
@@ -296,8 +309,10 @@ def _package_manifest(
     dataset_publication_grade: bool,
     dataset_publication_grade_reason: str,
     candidate_library_publication_grade: bool,
+    candidate_library_publication_grade_reason: str,
     publication_grade: bool,
     publication_grade_reason: str,
+    publication_grade_reasons: list[str],
     input_scope: str,
     input_path: Path,
     candidate_source_path: Path | None,
@@ -357,9 +372,11 @@ def _package_manifest(
         "verification_level": verification_level,
         "publication_grade": publication_grade,
         "publication_grade_reason": publication_grade_reason,
+        "publication_grade_reasons": publication_grade_reasons,
         "dataset_publication_grade": dataset_publication_grade,
         "dataset_publication_grade_reason": dataset_publication_grade_reason,
         "candidate_library_publication_grade": candidate_library_publication_grade,
+        "candidate_library_publication_grade_reason": candidate_library_publication_grade_reason,
         "input_scope": input_scope,
         "source_columns_is_smoke_only": evidence_mode == "source-columns",
         "max_rows": max_rows,
@@ -432,17 +449,28 @@ def _verification_level(evidence_mode: str) -> str:
 def _publication_grade_reason(
     *,
     publication_grade: bool,
-    dataset_publication_grade: bool,
-    dataset_publication_grade_reason: str,
-    candidate_library_publication_grade: bool,
+    publication_grade_reasons: list[str],
 ) -> str:
     if publication_grade:
         return "all publication-grade gates passed"
-    if not dataset_publication_grade:
-        return dataset_publication_grade_reason
-    if not candidate_library_publication_grade:
-        return "candidate library is offline-normalized"
+    if publication_grade_reasons:
+        return publication_grade_reasons[0]
     return "publication-grade gates failed"
+
+
+def _publication_grade_reasons(
+    *,
+    dataset_publication_grade: bool,
+    dataset_publication_grade_reason: str,
+    candidate_library_publication_grade: bool,
+    candidate_library_publication_grade_reason: str,
+) -> list[str]:
+    reasons: list[str] = []
+    if not dataset_publication_grade:
+        reasons.append(dataset_publication_grade_reason)
+    if not candidate_library_publication_grade:
+        reasons.append(candidate_library_publication_grade_reason)
+    return reasons
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:

--- a/hybrid_agent_exploration/src/run_verified_discovery.py
+++ b/hybrid_agent_exploration/src/run_verified_discovery.py
@@ -23,6 +23,7 @@ from screening.verified_discovery_workflow import VerifiedDiscoveryWorkflow
 
 
 EVIDENCE_MODES = ("external-cached", "source-columns")
+INPUT_SCOPES = ("selected-subset", "full-source")
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
 
@@ -139,6 +140,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--top-k", type=int, default=100, help="Number of ranked candidates to emit.")
     parser.add_argument("--min-verified-rows", type=int, default=10, help="Minimum strict verified training rows.")
     parser.add_argument("--max-rows", type=int, help="Optional input row cap for smoke runs.")
+    parser.add_argument(
+        "--input-scope",
+        choices=INPUT_SCOPES,
+        default="selected-subset",
+        help="Declare whether the input is the full source table or a selected subset.",
+    )
     return parser.parse_args(argv)
 
 
@@ -148,10 +155,18 @@ def main(argv: list[str] | None = None) -> int:
     df = load_input(args.input, max_rows=args.max_rows)
     cache_dir = Path(args.cache_dir) if args.cache_dir else default_cache_dir(args.dataset_id)
     authenticator = build_authenticator(args.evidence_mode, df, cache_dir)
+    publication_grade, publication_grade_reason = publication_grade_gate(
+        evidence_mode=args.evidence_mode,
+        input_scope=args.input_scope,
+        max_rows=args.max_rows,
+    )
     run_metadata = {
         "evidence_mode": args.evidence_mode,
         "verification_level": "external_cached" if args.evidence_mode == "external-cached" else "source_columns_only",
-        "publication_grade": args.evidence_mode == "external-cached",
+        "publication_grade": publication_grade,
+        "publication_grade_reason": publication_grade_reason,
+        "input_scope": args.input_scope,
+        "max_rows_is_smoke_only": args.max_rows is not None,
         "source_columns_is_smoke_only": args.evidence_mode == "source-columns",
         "input_path": str(Path(args.input)),
         "max_rows": args.max_rows,
@@ -177,6 +192,18 @@ def main(argv: list[str] | None = None) -> int:
     print(f"[verified-discovery] quarantine_rows={artifacts.quarantine_rows}")
     print(f"[verified-discovery] ranked_candidates={artifacts.ranked_candidates}")
     return 0
+
+
+def publication_grade_gate(*, evidence_mode: str, input_scope: str, max_rows: int | None) -> tuple[bool, str]:
+    """Return whether dataset evidence can be labeled publication-grade."""
+
+    if evidence_mode != "external-cached":
+        return False, "evidence_mode is not external-cached"
+    if max_rows is not None:
+        return False, "max_rows smoke subset"
+    if input_scope != "full-source":
+        return False, "input_scope is not full-source"
+    return True, "external-cached full-source input"
 
 
 def _clean_text(value: Any) -> str:

--- a/hybrid_agent_exploration/src/run_verified_discovery.py
+++ b/hybrid_agent_exploration/src/run_verified_discovery.py
@@ -197,6 +197,8 @@ def main(argv: list[str] | None = None) -> int:
 def publication_grade_gate(*, evidence_mode: str, input_scope: str, max_rows: int | None) -> tuple[bool, str]:
     """Return whether dataset evidence can be labeled publication-grade."""
 
+    if input_scope not in INPUT_SCOPES:
+        raise ValueError(f"input_scope must be one of {', '.join(INPUT_SCOPES)}; got {input_scope!r}")
     if evidence_mode != "external-cached":
         return False, "evidence_mode is not external-cached"
     if max_rows is not None:

--- a/tests/test_research_package_runner.py
+++ b/tests/test_research_package_runner.py
@@ -275,6 +275,11 @@ def test_external_cached_candidate_source_does_not_overclaim_publication_grade(t
     assert package_manifest["candidate_library_publication_grade"] is False
     assert package_manifest["publication_grade"] is False
     assert package_manifest["publication_grade_reason"] == "input_scope is not full-source"
+    assert package_manifest["publication_grade_reasons"] == [
+        "input_scope is not full-source",
+        "candidate library is offline-normalized",
+    ]
+    assert package_manifest["candidate_library_publication_grade_reason"] == "candidate library is offline-normalized"
 
     run_manifest = json.loads(
         (package.report_dir / "main_text" / "run_manifest.json").read_text(encoding="utf-8")
@@ -283,6 +288,10 @@ def test_external_cached_candidate_source_does_not_overclaim_publication_grade(t
     assert run_manifest["evidence_context"]["dataset_publication_grade"] is False
     assert run_manifest["evidence_context"]["candidate_library_publication_grade"] is False
     assert run_manifest["evidence_context"]["input_scope"] == "selected-subset"
+    assert run_manifest["evidence_context"]["publication_grade_reasons"] == [
+        "input_scope is not full-source",
+        "candidate library is offline-normalized",
+    ]
 
     si_text = (package.report_dir / "si" / "supporting_information.md").read_text(encoding="utf-8")
     assert "Publication-grade flag: `False`" in si_text
@@ -328,6 +337,34 @@ def test_external_cached_full_source_without_candidate_source_can_be_publication
     assert package_manifest["candidate_library_publication_grade"] is True
     assert package_manifest["publication_grade"] is True
     assert package_manifest["publication_grade_reason"] == "all publication-grade gates passed"
+    assert package_manifest["publication_grade_reasons"] == []
+
+
+def test_research_package_rejects_invalid_input_scope(tmp_path):
+    from run_research_package import run_research_package
+
+    raw_csv = tmp_path / "raw_psc.csv"
+    pd.DataFrame(
+        [
+            _raw_record("row-001", "10.1021/acs.jpclett.6c00119", "C", 0.25),
+            _raw_record("row-002", "10.1021/acs.jpclett.6c00120", "CC", 0.50),
+        ]
+    ).to_csv(raw_csv, index=False)
+
+    try:
+        run_research_package(
+            input_path=raw_csv,
+            output_dir=tmp_path / "research_package",
+            dataset_id="invalid-scope",
+            evidence_mode="source-columns",
+            input_scope="hand-picked",
+            min_verified_rows=2,
+            top_k=1,
+        )
+    except ValueError as exc:
+        assert "input_scope" in str(exc)
+    else:
+        raise AssertionError("invalid input_scope should fail")
 
 
 def test_external_cached_max_rows_does_not_overclaim_publication_grade(tmp_path, monkeypatch):

--- a/tests/test_research_package_runner.py
+++ b/tests/test_research_package_runner.py
@@ -270,20 +270,64 @@ def test_external_cached_candidate_source_does_not_overclaim_publication_grade(t
     )
 
     package_manifest = json.loads(package.package_manifest_json.read_text(encoding="utf-8"))
-    assert package_manifest["dataset_publication_grade"] is True
+    assert package_manifest["input_scope"] == "selected-subset"
+    assert package_manifest["dataset_publication_grade"] is False
     assert package_manifest["candidate_library_publication_grade"] is False
     assert package_manifest["publication_grade"] is False
+    assert package_manifest["publication_grade_reason"] == "input_scope is not full-source"
 
     run_manifest = json.loads(
         (package.report_dir / "main_text" / "run_manifest.json").read_text(encoding="utf-8")
     )
     assert run_manifest["evidence_context"]["publication_grade"] is False
-    assert run_manifest["evidence_context"]["dataset_publication_grade"] is True
+    assert run_manifest["evidence_context"]["dataset_publication_grade"] is False
     assert run_manifest["evidence_context"]["candidate_library_publication_grade"] is False
+    assert run_manifest["evidence_context"]["input_scope"] == "selected-subset"
 
     si_text = (package.report_dir / "si" / "supporting_information.md").read_text(encoding="utf-8")
     assert "Publication-grade flag: `False`" in si_text
     assert "Candidate-library publication-grade flag: `False`" in si_text
+
+
+def test_external_cached_full_source_without_candidate_source_can_be_publication_grade(tmp_path, monkeypatch):
+    import run_research_package as runner
+    from harness.authenticity import RealDataAuthenticator
+    from run_verified_discovery import SourceColumnMoleculeVerifier, SourceColumnReferenceVerifier
+
+    raw_csv = tmp_path / "raw_psc.csv"
+    pd.DataFrame(
+        [
+            _raw_record("row-001", "10.1021/acs.jpclett.6c00119", "C", 0.25),
+            _raw_record("row-002", "10.1021/acs.jpclett.6c00120", "CC", 0.50),
+            _raw_record("row-003", "10.1021/acs.jpclett.6c00121", "CCC", 0.75),
+            _raw_record("row-004", "10.1021/acs.jpclett.6c00122", "CCCC", 1.00),
+        ]
+    ).to_csv(raw_csv, index=False)
+
+    def build_source_column_authenticator(evidence_mode, df, cache_dir):
+        return RealDataAuthenticator(
+            reference_verifier=SourceColumnReferenceVerifier(df),
+            molecule_verifier=SourceColumnMoleculeVerifier(),
+        )
+
+    monkeypatch.setattr(runner, "build_authenticator", build_source_column_authenticator)
+
+    package = runner.run_research_package(
+        input_path=raw_csv,
+        output_dir=tmp_path / "research_package",
+        dataset_id="external-cached-full-source",
+        evidence_mode="external-cached",
+        input_scope="full-source",
+        min_verified_rows=4,
+        top_k=1,
+    )
+
+    package_manifest = json.loads(package.package_manifest_json.read_text(encoding="utf-8"))
+    assert package_manifest["input_scope"] == "full-source"
+    assert package_manifest["dataset_publication_grade"] is True
+    assert package_manifest["candidate_library_publication_grade"] is True
+    assert package_manifest["publication_grade"] is True
+    assert package_manifest["publication_grade_reason"] == "all publication-grade gates passed"
 
 
 def test_external_cached_max_rows_does_not_overclaim_publication_grade(tmp_path, monkeypatch):

--- a/tests/test_run_verified_discovery_cli.py
+++ b/tests/test_run_verified_discovery_cli.py
@@ -91,6 +91,100 @@ def test_cli_external_cached_mode_initializes_cache_paths(tmp_path):
     assert authenticator.molecule_verifier.cache_path == cache_dir / "molecule_cache.json"
 
 
+def test_cli_defaults_external_cached_subset_to_non_publication_grade(tmp_path, monkeypatch):
+    import run_verified_discovery as runner
+    from harness.authenticity import RealDataAuthenticator
+    from run_verified_discovery import SourceColumnMoleculeVerifier, SourceColumnReferenceVerifier
+
+    input_csv = tmp_path / "raw.csv"
+    output_dir = tmp_path / "out"
+    pd.DataFrame(
+        [
+            _record("row-001", "10.1021/acs.jpclett.6c00119", "C", 0.25),
+            _record("row-002", "10.1021/acs.jpclett.6c00120", "CC", 0.50),
+        ]
+    ).to_csv(input_csv, index=False)
+
+    def build_source_column_authenticator(evidence_mode, df, cache_dir):
+        return RealDataAuthenticator(
+            reference_verifier=SourceColumnReferenceVerifier(df),
+            molecule_verifier=SourceColumnMoleculeVerifier(),
+        )
+
+    monkeypatch.setattr(runner, "build_authenticator", build_source_column_authenticator)
+
+    exit_code = runner.main(
+        [
+            "--input",
+            str(input_csv),
+            "--output-dir",
+            str(output_dir),
+            "--dataset-id",
+            "external-subset-fixture",
+            "--evidence-mode",
+            "external-cached",
+            "--min-verified-rows",
+            "2",
+            "--top-k",
+            "1",
+        ]
+    )
+
+    assert exit_code == 0
+    manifest = json.loads((output_dir / "workflow_manifest.json").read_text(encoding="utf-8"))
+    assert manifest["input_scope"] == "selected-subset"
+    assert manifest["publication_grade"] is False
+    assert manifest["publication_grade_reason"] == "input_scope is not full-source"
+
+
+def test_cli_full_source_external_cached_can_be_publication_grade(tmp_path, monkeypatch):
+    import run_verified_discovery as runner
+    from harness.authenticity import RealDataAuthenticator
+    from run_verified_discovery import SourceColumnMoleculeVerifier, SourceColumnReferenceVerifier
+
+    input_csv = tmp_path / "raw.csv"
+    output_dir = tmp_path / "out"
+    pd.DataFrame(
+        [
+            _record("row-001", "10.1021/acs.jpclett.6c00119", "C", 0.25),
+            _record("row-002", "10.1021/acs.jpclett.6c00120", "CC", 0.50),
+        ]
+    ).to_csv(input_csv, index=False)
+
+    def build_source_column_authenticator(evidence_mode, df, cache_dir):
+        return RealDataAuthenticator(
+            reference_verifier=SourceColumnReferenceVerifier(df),
+            molecule_verifier=SourceColumnMoleculeVerifier(),
+        )
+
+    monkeypatch.setattr(runner, "build_authenticator", build_source_column_authenticator)
+
+    exit_code = runner.main(
+        [
+            "--input",
+            str(input_csv),
+            "--output-dir",
+            str(output_dir),
+            "--dataset-id",
+            "external-full-source-fixture",
+            "--evidence-mode",
+            "external-cached",
+            "--input-scope",
+            "full-source",
+            "--min-verified-rows",
+            "2",
+            "--top-k",
+            "1",
+        ]
+    )
+
+    assert exit_code == 0
+    manifest = json.loads((output_dir / "workflow_manifest.json").read_text(encoding="utf-8"))
+    assert manifest["input_scope"] == "full-source"
+    assert manifest["publication_grade"] is True
+    assert manifest["publication_grade_reason"] == "external-cached full-source input"
+
+
 def test_gitignore_excludes_verified_discovery_runtime_outputs():
     gitignore = (Path(__file__).resolve().parents[1] / ".gitignore").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- add explicit input-scope metadata to direct verified-discovery and full research-package runners
- require external-cached + full-source + no max_rows before dataset evidence can be publication-grade
- propagate publication-grade reasons into workflow, package, and report evidence context

## Verification
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_run_verified_discovery_cli.py tests/test_research_package_runner.py tests/test_source_completeness.py tests/test_top_journal_reporting.py tests/test_evidence_cache_verifiers.py tests/test_verified_discovery_workflow.py
- python -m py_compile hybrid_agent_exploration/src/run_verified_discovery.py hybrid_agent_exploration/src/run_research_package.py && git diff --check
- real external-cached 20-row smoke: 5 verified / 15 quarantined; publication_grade=false with reason max_rows smoke subset