### PR TITLE
feat: add canonical research package make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,14 @@ SMOKE_MIN_VERIFIED_ROWS ?= 1
 SMOKE_TOP_K ?= 10
 
 RUN_RESEARCH_PACKAGE := hybrid_agent_exploration/src/run_research_package.py
+ROOT_PROVENANCE_MANIFEST := hybrid_agent_exploration/src/reporting/root_provenance_manifest.py
+VERIFIED_DISCOVERY_DIR := $(ARTIFACT_DIR)/verified_discovery
+REPORT_DIR := $(ARTIFACT_DIR)/report_bundle/main_text
+SI_DIR := $(ARTIFACT_DIR)/report_bundle/si
+CANDIDATE_LIBRARY_DIR := $(ARTIFACT_DIR)/candidate_library
+SOURCE_COMPLETENESS_DIR := $(ARTIFACT_DIR)/source_completeness
+PACKAGE_MANIFEST := $(ARTIFACT_DIR)/package_manifest.json
+ROOT_PROVENANCE_JSON := $(ARTIFACT_DIR)/provenance_manifest.json
 MAIN_TEXT_MD := $(ARTIFACT_DIR)/report_bundle/main_text/main_text_report.md
 MAIN_TEXT_PDF := $(ARTIFACT_DIR)/report_bundle/main_text/main_text_report.pdf
 SI_MD := $(ARTIFACT_DIR)/report_bundle/si/supporting_information.md
@@ -50,6 +58,20 @@ research-package-pdf:
 	@test -f $(SI_MD) || { echo "missing supporting information markdown: $(SI_MD). Run make research-package first or set ARTIFACT_DIR." >&2; exit 2; }
 	pandoc $(MAIN_TEXT_MD) -o $(MAIN_TEXT_PDF)
 	pandoc $(SI_MD) -o $(SI_PDF)
+	@candidate_library_args=""; \
+	if [ -d "$(CANDIDATE_LIBRARY_DIR)" ]; then candidate_library_args="--candidate-library-dir $(CANDIDATE_LIBRARY_DIR)"; fi; \
+	candidate_source_args=""; \
+	if [ -n "$(CANDIDATE_SOURCE)" ]; then candidate_source_args="--candidate-source-path $(CANDIDATE_SOURCE)"; fi; \
+	$(PYTHON) $(ROOT_PROVENANCE_MANIFEST) \
+		--verified-discovery-artifact-dir $(VERIFIED_DISCOVERY_DIR) \
+		--report-dir $(REPORT_DIR) \
+		--si-dir $(SI_DIR) \
+		--source-completeness-dir $(SOURCE_COMPLETENESS_DIR) \
+		--package-manifest-path $(PACKAGE_MANIFEST) \
+		--input-path $(SOURCE_TABLE) \
+		--output-path $(ROOT_PROVENANCE_JSON) \
+		$$candidate_library_args \
+		$$candidate_source_args
 
 test-research-package:
 	PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 $(PYTHON) -m pytest -q \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,59 @@
+PYTHON ?= python
+
+SOURCE_TABLE ?= /share/yhm/test/20260216_with_chemical_merge_fast/merged_llm_crossref_data_streaming_with_chemical_data_fast.xlsx
+DATASET_ID ?= canonical-research-package
+ARTIFACT_DIR ?= hybrid_agent_exploration/results/verified_discovery_runs/$(DATASET_ID)
+EVIDENCE_MODE ?= external-cached
+INPUT_SCOPE ?= selected-subset
+MIN_VERIFIED_ROWS ?= 10
+TOP_K ?= 100
+SMOKE_MAX_ROWS ?= 25
+SMOKE_MIN_VERIFIED_ROWS ?= 1
+SMOKE_TOP_K ?= 10
+
+RUN_RESEARCH_PACKAGE := hybrid_agent_exploration/src/run_research_package.py
+MAIN_TEXT_MD := $(ARTIFACT_DIR)/report_bundle/main_text/main_text_report.md
+MAIN_TEXT_PDF := $(ARTIFACT_DIR)/report_bundle/main_text/main_text_report.pdf
+SI_MD := $(ARTIFACT_DIR)/report_bundle/si/supporting_information.md
+SI_PDF := $(ARTIFACT_DIR)/report_bundle/si/supporting_information.pdf
+
+CANDIDATE_SOURCE_ARGS := $(if $(CANDIDATE_SOURCE),--candidate-source $(CANDIDATE_SOURCE),)
+CANDIDATE_SOURCE_NAME_ARGS := $(if $(CANDIDATE_SOURCE_NAME),--candidate-source-name $(CANDIDATE_SOURCE_NAME),)
+
+.PHONY: research-package research-package-smoke research-package-pdf test-research-package
+
+research-package:
+	$(PYTHON) $(RUN_RESEARCH_PACKAGE) \
+		--input $(SOURCE_TABLE) \
+		--output-dir $(ARTIFACT_DIR) \
+		--dataset-id $(DATASET_ID) \
+		--evidence-mode $(EVIDENCE_MODE) \
+		--input-scope $(INPUT_SCOPE) \
+		--min-verified-rows $(MIN_VERIFIED_ROWS) \
+		--top-k $(TOP_K) \
+		$(CANDIDATE_SOURCE_ARGS) \
+		$(CANDIDATE_SOURCE_NAME_ARGS) \
+		$(EXTRA_RUN_ARGS)
+
+research-package-smoke:
+	$(MAKE) research-package \
+		DATASET_ID=$(DATASET_ID)-smoke \
+		ARTIFACT_DIR=hybrid_agent_exploration/results/verified_discovery_runs/$(DATASET_ID)-smoke \
+		EVIDENCE_MODE=source-columns \
+		MIN_VERIFIED_ROWS=$(SMOKE_MIN_VERIFIED_ROWS) \
+		TOP_K=$(SMOKE_TOP_K) \
+		EXTRA_RUN_ARGS="--max-rows $(SMOKE_MAX_ROWS)"
+
+research-package-pdf:
+	@command -v pandoc >/dev/null 2>&1 || { echo "pandoc is required for research-package-pdf. Install pandoc and rerun this target." >&2; exit 127; }
+	@test -f $(MAIN_TEXT_MD) || { echo "missing main text markdown: $(MAIN_TEXT_MD). Run make research-package first or set ARTIFACT_DIR." >&2; exit 2; }
+	@test -f $(SI_MD) || { echo "missing supporting information markdown: $(SI_MD). Run make research-package first or set ARTIFACT_DIR." >&2; exit 2; }
+	pandoc $(MAIN_TEXT_MD) -o $(MAIN_TEXT_PDF)
+	pandoc $(SI_MD) -o $(SI_PDF)
+
+test-research-package:
+	PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 $(PYTHON) -m pytest -q \
+		tests/test_canonical_make_targets.py \
+		tests/test_research_package_runner.py \
+		tests/test_run_verified_discovery_cli.py \
+		tests/test_root_provenance_manifest.py

--- a/README.md
+++ b/README.md
@@ -59,6 +59,50 @@ wget -O data/raw/perovskite_database_all.csv \
 python scripts/data_overview.py
 ```
 
+### 生成规范研究包
+
+根目录 `Makefile` 提供规范入口，输出默认写入已忽略的
+`hybrid_agent_exploration/results/verified_discovery_runs/` 目录：
+
+```bash
+make research-package
+make research-package-pdf
+make test-research-package
+```
+
+常用环境变量：
+
+- `SOURCE_TABLE`: 输入 CSV/XLSX 源表，默认使用本项目 QSPR 合并表。
+- `DATASET_ID`: 稳定数据集或运行标识，默认 `canonical-research-package`。
+- `ARTIFACT_DIR`: 研究包输出目录，默认 `hybrid_agent_exploration/results/verified_discovery_runs/$(DATASET_ID)`。
+- `EVIDENCE_MODE`: 证据模式，支持 `external-cached` 或 `source-columns`。
+- `INPUT_SCOPE`: 输入范围声明，支持 `selected-subset` 或 `full-source`。
+- `MIN_VERIFIED_ROWS`: 最少验证行数。
+- `TOP_K`: 候选排序输出数量。
+- `CANDIDATE_SOURCE`: 可选外部候选源 CSV/XLSX。
+- `CANDIDATE_SOURCE_NAME`: 可选外部候选源名称。
+
+示例：
+
+```bash
+SOURCE_TABLE=/path/to/source.xlsx \
+DATASET_ID=jpcl-full-source \
+EVIDENCE_MODE=external-cached \
+INPUT_SCOPE=full-source \
+MIN_VERIFIED_ROWS=10 \
+TOP_K=100 \
+make research-package
+```
+
+快速冒烟运行可使用：
+
+```bash
+SOURCE_TABLE=/path/to/source.csv make research-package-smoke
+```
+
+`research-package-pdf` 会把已生成的 `main_text_report.md` 和
+`supporting_information.md` 转换为 PDF；如果未安装 `pandoc`，该目标会直接失败并提示安装。
+
 ### 运行 EDA 分析
 
 ```bash

--- a/tests/test_canonical_make_targets.py
+++ b/tests/test_canonical_make_targets.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MAKEFILE = ROOT / "Makefile"
+
+
+def _make_dry_run(target: str, **variables: str) -> str:
+    args = ["make", "-n", target]
+    args.extend(f"{key}={value}" for key, value in variables.items())
+    result = subprocess.run(
+        args,
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout
+    return result.stdout
+
+
+def test_canonical_research_package_targets_are_declared():
+    text = MAKEFILE.read_text(encoding="utf-8")
+
+    for target in (
+        "research-package",
+        "research-package-smoke",
+        "research-package-pdf",
+        "test-research-package",
+    ):
+        assert f".PHONY: {target}" in text or f" {target}" in text
+        assert f"{target}:" in text
+
+
+def test_research_package_dry_run_uses_canonical_runner_and_ignored_artifact_dir():
+    output = _make_dry_run(
+        "research-package",
+        SOURCE_TABLE="/tmp/source.csv",
+        DATASET_ID="unit-dataset",
+        EVIDENCE_MODE="source-columns",
+        INPUT_SCOPE="full-source",
+        MIN_VERIFIED_ROWS="3",
+        TOP_K="7",
+        CANDIDATE_SOURCE="/tmp/candidates.csv",
+        CANDIDATE_SOURCE_NAME="unit-candidates",
+    )
+
+    assert "hybrid_agent_exploration/src/run_research_package.py" in output
+    assert "--input /tmp/source.csv" in output
+    assert "--dataset-id unit-dataset" in output
+    assert "--evidence-mode source-columns" in output
+    assert "--input-scope full-source" in output
+    assert "--min-verified-rows 3" in output
+    assert "--top-k 7" in output
+    assert "--candidate-source /tmp/candidates.csv" in output
+    assert "--candidate-source-name unit-candidates" in output
+    assert "hybrid_agent_exploration/results/verified_discovery_runs/unit-dataset" in output
+
+
+def test_smoke_target_dry_run_caps_rows_in_ignored_artifact_dir():
+    output = _make_dry_run("research-package-smoke", SOURCE_TABLE="/tmp/source.csv")
+
+    assert "hybrid_agent_exploration/src/run_research_package.py" in output
+    assert "--max-rows" in output
+    assert "hybrid_agent_exploration/results/verified_discovery_runs/" in output
+
+
+def test_pdf_target_dry_run_checks_pandoc_and_exports_report_pdfs():
+    output = _make_dry_run("research-package-pdf", ARTIFACT_DIR="/tmp/artifacts")
+
+    assert "command -v pandoc" in output
+    assert "main_text/main_text_report.md" in output
+    assert "main_text/main_text_report.pdf" in output
+    assert "si/supporting_information.md" in output
+    assert "si/supporting_information.pdf" in output
+    assert "pandoc" in output
+
+
+def test_test_research_package_target_runs_canonical_pytest_slice():
+    output = _make_dry_run("test-research-package")
+
+    assert "PYTEST_DISABLE_PLUGIN_AUTOLOAD=1" in output
+    assert "tests/test_canonical_make_targets.py" in output
+    assert "tests/test_research_package_runner.py" in output
+    assert "tests/test_run_verified_discovery_cli.py" in output
+    assert "tests/test_root_provenance_manifest.py" in output

--- a/tests/test_canonical_make_targets.py
+++ b/tests/test_canonical_make_targets.py
@@ -78,6 +78,8 @@ def test_pdf_target_dry_run_checks_pandoc_and_exports_report_pdfs():
     assert "si/supporting_information.md" in output
     assert "si/supporting_information.pdf" in output
     assert "pandoc" in output
+    assert "hybrid_agent_exploration/src/reporting/root_provenance_manifest.py" in output
+    assert "--output-path /tmp/artifacts/provenance_manifest.json" in output
 
 
 def test_test_research_package_target_runs_canonical_pytest_slice():


### PR DESCRIPTION
## Summary
- add root Makefile targets for canonical research package generation, smoke runs, PDF export, and focused tests
- document the current research-package command surface and required environment variables in README
- make PDF export refresh the root provenance manifest so generated PDFs are indexed with the package artifacts

## Verification
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_canonical_make_targets.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests/test_canonical_make_targets.py tests/test_research_package_runner.py tests/test_run_verified_discovery_cli.py tests/test_root_provenance_manifest.py`
- `make -n research-package SOURCE_TABLE=/tmp/source.csv DATASET_ID=demo-dataset EVIDENCE_MODE=source-columns INPUT_SCOPE=full-source MIN_VERIFIED_ROWS=3 TOP_K=7 CANDIDATE_SOURCE=/tmp/candidates.csv CANDIDATE_SOURCE_NAME=demo-candidates`
- `make -n research-package-smoke SOURCE_TABLE=/tmp/source.csv`
- `make -n research-package-pdf ARTIFACT_DIR=/tmp/artifacts`
- `make -n test-research-package`
