### PR TITLE
fix: resolve workflow outputs from relative packages

### DIFF
--- a/hybrid_agent_exploration/src/verify_research_package.py
+++ b/hybrid_agent_exploration/src/verify_research_package.py
@@ -444,7 +444,7 @@ def _check_workflow_outputs(manifest: dict[str, Any], root: Path, errors: list[s
             errors.append(f"verified_discovery/workflow_manifest.json: outputs.{key} is required")
             continue
         _check_path(
-            root,
+            Path("."),
             discovery_root / str(value),
             kind="file",
             errors=errors,

--- a/tests/test_research_package_contract.py
+++ b/tests/test_research_package_contract.py
@@ -101,6 +101,34 @@ def test_contract_verifies_complete_research_package_with_candidate_library(tmp_
     assert "source_completeness/source_completeness.json" in result["checks"]["required_artifacts"]["paths"]
 
 
+def test_contract_verifies_relative_package_dir_workflow_outputs(tmp_path, monkeypatch):
+    from run_research_package import run_research_package
+    from verify_research_package import verify_research_package
+
+    raw_csv = tmp_path / "raw_psc.csv"
+    candidate_csv = tmp_path / "candidate_source.csv"
+    _write_source_table(raw_csv)
+    _candidate_source().to_csv(candidate_csv, index=False)
+
+    package = run_research_package(
+        input_path=raw_csv,
+        output_dir=tmp_path / "research_package",
+        dataset_id="relative-package-fixture",
+        evidence_mode="source-columns",
+        candidate_source_path=candidate_csv,
+        candidate_source_name="fixture-vendor-source",
+        min_verified_rows=4,
+        top_k=1,
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    result = verify_research_package(Path(package.output_dir.name), require_candidate_library=True)
+
+    assert result["status"] == "passed"
+    assert result["summary"]["dataset_id"] == "relative-package-fixture"
+
+
 def test_contract_fails_when_required_candidate_library_is_absent(tmp_path):
     from run_research_package import run_research_package
     from verify_research_package import ResearchPackageContractError, verify_research_package


### PR DESCRIPTION
## Summary
- add regression coverage for verifying a research package through a relative package path
- fix workflow-output checks so already-resolved paths are not resolved against the package root a second time
- unblock contract validation for generated packages invoked with relative artifact directories

## Verification
- `uv run --with pytest python -m pytest -q tests/test_research_package_contract.py`
- `uv run python hybrid_agent_exploration/src/verify_research_package.py --package-dir ../final-candidate-closure/hybrid_agent_exploration/results/verified_discovery_runs/psc-additive-closure-source-columns-smoke --require-candidate-library`
- `python -m py_compile hybrid_agent_exploration/src/verify_research_package.py && git diff --check`
