### PR TITLE
feat: add research package verify target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ PANDOC_MAINFONT ?= DejaVu Serif
 
 RUN_RESEARCH_PACKAGE := hybrid_agent_exploration/src/run_research_package.py
 ROOT_PROVENANCE_MANIFEST := hybrid_agent_exploration/src/reporting/root_provenance_manifest.py
+VERIFY_RESEARCH_PACKAGE := hybrid_agent_exploration/src/verify_research_package.py
 VERIFIED_DISCOVERY_DIR := $(ARTIFACT_DIR)/verified_discovery
 REPORT_DIR := $(ARTIFACT_DIR)/report_bundle/main_text
 SI_DIR := $(ARTIFACT_DIR)/report_bundle/si
@@ -31,8 +32,10 @@ SI_RESOURCE_PATH := $(SI_DIR):$(ARTIFACT_DIR)
 
 CANDIDATE_SOURCE_ARGS := $(if $(CANDIDATE_SOURCE),--candidate-source $(CANDIDATE_SOURCE),)
 CANDIDATE_SOURCE_NAME_ARGS := $(if $(CANDIDATE_SOURCE_NAME),--candidate-source-name $(CANDIDATE_SOURCE_NAME),)
+VERIFY_CANDIDATE_LIBRARY_ARGS := $(if $(REQUIRE_CANDIDATE_LIBRARY),--require-candidate-library,)
+VERIFY_EVIDENCE_CACHE_ARGS := $(if $(REQUIRE_EVIDENCE_CACHE),--require-evidence-cache,)
 
-.PHONY: research-package research-package-smoke research-package-pdf test-research-package
+.PHONY: research-package research-package-smoke research-package-pdf research-package-verify test-research-package
 
 research-package:
 	$(PYTHON) $(RUN_RESEARCH_PACKAGE) \
@@ -76,6 +79,12 @@ research-package-pdf:
 		--output-path $(ROOT_PROVENANCE_JSON) \
 		$$candidate_library_args \
 		$$candidate_source_args
+
+research-package-verify:
+	$(PYTHON) $(VERIFY_RESEARCH_PACKAGE) \
+		--package-dir $(ARTIFACT_DIR) \
+		$(VERIFY_CANDIDATE_LIBRARY_ARGS) \
+		$(VERIFY_EVIDENCE_CACHE_ARGS)
 
 test-research-package:
 	PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 $(PYTHON) -m pytest -q \

--- a/tests/test_canonical_make_targets.py
+++ b/tests/test_canonical_make_targets.py
@@ -30,6 +30,7 @@ def test_canonical_research_package_targets_are_declared():
         "research-package",
         "research-package-smoke",
         "research-package-pdf",
+        "research-package-verify",
         "test-research-package",
     ):
         assert f".PHONY: {target}" in text or f" {target}" in text
@@ -83,6 +84,20 @@ def test_pdf_target_dry_run_checks_pandoc_and_exports_report_pdfs():
     assert "pandoc" in output
     assert "hybrid_agent_exploration/src/reporting/root_provenance_manifest.py" in output
     assert "--output-path /tmp/artifacts/provenance_manifest.json" in output
+
+
+def test_verify_target_dry_run_runs_contract_verifier_with_optional_gates():
+    output = _make_dry_run(
+        "research-package-verify",
+        ARTIFACT_DIR="/tmp/artifacts",
+        REQUIRE_CANDIDATE_LIBRARY="1",
+        REQUIRE_EVIDENCE_CACHE="1",
+    )
+
+    assert "hybrid_agent_exploration/src/verify_research_package.py" in output
+    assert "--package-dir /tmp/artifacts" in output
+    assert "--require-candidate-library" in output
+    assert "--require-evidence-cache" in output
 
 
 def test_test_research_package_target_runs_canonical_pytest_slice():


### PR DESCRIPTION
## Summary
- add `make research-package-verify` as the canonical artifact-contract validation entrypoint
- allow optional `REQUIRE_CANDIDATE_LIBRARY=1` and `REQUIRE_EVIDENCE_CACHE=1` gates
- extend Makefile dry-run tests so package generation has a reproducible verification command

## Verification
- `uv run --with pytest python -m pytest -q tests/test_canonical_make_targets.py tests/test_research_package_contract.py`
- `make -n research-package-verify ARTIFACT_DIR=/tmp/artifacts REQUIRE_CANDIDATE_LIBRARY=1 REQUIRE_EVIDENCE_CACHE=1`
- `git diff --check`
