### PR TITLE
feat: add external evidence cache preflight

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,9 @@ TOP_K ?= 100
 SMOKE_MAX_ROWS ?= 25
 SMOKE_MIN_VERIFIED_ROWS ?= 1
 SMOKE_TOP_K ?= 10
-CACHE_PREFLIGHT_MAX_ROWS ?= $(SMOKE_MAX_ROWS)
-EVIDENCE_CACHE_DIR ?= hybrid_agent_exploration/.cache/verified_discovery/$(DATASET_ID)/evidence_cache
+CACHE_PREFLIGHT_MAX_ROWS ?=
+CACHE_PREFLIGHT_SMOKE_MAX_ROWS ?= $(SMOKE_MAX_ROWS)
+EVIDENCE_CACHE_DIR ?=
 PANDOC_PDF_ENGINE ?= xelatex
 PANDOC_MAINFONT ?= DejaVu Serif
 
@@ -36,11 +37,12 @@ SI_RESOURCE_PATH := $(SI_DIR):$(ARTIFACT_DIR)
 
 CANDIDATE_SOURCE_ARGS := $(if $(CANDIDATE_SOURCE),--candidate-source $(CANDIDATE_SOURCE),)
 CANDIDATE_SOURCE_NAME_ARGS := $(if $(CANDIDATE_SOURCE_NAME),--candidate-source-name $(CANDIDATE_SOURCE_NAME),)
+CACHE_PREFLIGHT_CACHE_DIR_ARGS := $(if $(EVIDENCE_CACHE_DIR),--cache-dir $(EVIDENCE_CACHE_DIR),)
 CACHE_PREFLIGHT_MAX_ROWS_ARGS := $(if $(CACHE_PREFLIGHT_MAX_ROWS),--max-rows $(CACHE_PREFLIGHT_MAX_ROWS),)
 VERIFY_CANDIDATE_LIBRARY_ARGS := $(if $(REQUIRE_CANDIDATE_LIBRARY),--require-candidate-library,)
 VERIFY_EVIDENCE_CACHE_ARGS := $(if $(REQUIRE_EVIDENCE_CACHE),--require-evidence-cache,)
 
-.PHONY: research-package research-package-smoke research-package-cache-preflight research-package-pdf research-package-verify test-research-package
+.PHONY: research-package research-package-smoke research-package-cache-preflight research-package-cache-preflight-smoke research-package-pdf research-package-verify test-research-package
 
 research-package:
 	$(PYTHON) $(RUN_RESEARCH_PACKAGE) \
@@ -69,9 +71,13 @@ research-package-cache-preflight:
 		--input $(SOURCE_TABLE) \
 		--dataset-id $(DATASET_ID) \
 		--source-name $(notdir $(basename $(SOURCE_TABLE))) \
-		--cache-dir $(EVIDENCE_CACHE_DIR) \
 		--output-dir $(CACHE_PREFLIGHT_DIR) \
+		$(CACHE_PREFLIGHT_CACHE_DIR_ARGS) \
 		$(CACHE_PREFLIGHT_MAX_ROWS_ARGS)
+
+research-package-cache-preflight-smoke:
+	$(MAKE) research-package-cache-preflight \
+		CACHE_PREFLIGHT_MAX_ROWS=$(CACHE_PREFLIGHT_SMOKE_MAX_ROWS)
 
 research-package-pdf:
 	@command -v pandoc >/dev/null 2>&1 || { echo "pandoc is required for research-package-pdf. Install pandoc and rerun this target." >&2; exit 127; }

--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,17 @@ TOP_K ?= 100
 SMOKE_MAX_ROWS ?= 25
 SMOKE_MIN_VERIFIED_ROWS ?= 1
 SMOKE_TOP_K ?= 10
+CACHE_PREFLIGHT_MAX_ROWS ?= $(SMOKE_MAX_ROWS)
+EVIDENCE_CACHE_DIR ?= hybrid_agent_exploration/.cache/verified_discovery/$(DATASET_ID)/evidence_cache
 PANDOC_PDF_ENGINE ?= xelatex
 PANDOC_MAINFONT ?= DejaVu Serif
 
 RUN_RESEARCH_PACKAGE := hybrid_agent_exploration/src/run_research_package.py
+RUN_EVIDENCE_CACHE_PREFLIGHT := hybrid_agent_exploration/src/run_evidence_cache_preflight.py
 ROOT_PROVENANCE_MANIFEST := hybrid_agent_exploration/src/reporting/root_provenance_manifest.py
 VERIFY_RESEARCH_PACKAGE := hybrid_agent_exploration/src/verify_research_package.py
 VERIFIED_DISCOVERY_DIR := $(ARTIFACT_DIR)/verified_discovery
+CACHE_PREFLIGHT_DIR := $(ARTIFACT_DIR)/evidence_cache_preflight
 REPORT_DIR := $(ARTIFACT_DIR)/report_bundle/main_text
 SI_DIR := $(ARTIFACT_DIR)/report_bundle/si
 CANDIDATE_LIBRARY_DIR := $(ARTIFACT_DIR)/candidate_library
@@ -32,10 +36,11 @@ SI_RESOURCE_PATH := $(SI_DIR):$(ARTIFACT_DIR)
 
 CANDIDATE_SOURCE_ARGS := $(if $(CANDIDATE_SOURCE),--candidate-source $(CANDIDATE_SOURCE),)
 CANDIDATE_SOURCE_NAME_ARGS := $(if $(CANDIDATE_SOURCE_NAME),--candidate-source-name $(CANDIDATE_SOURCE_NAME),)
+CACHE_PREFLIGHT_MAX_ROWS_ARGS := $(if $(CACHE_PREFLIGHT_MAX_ROWS),--max-rows $(CACHE_PREFLIGHT_MAX_ROWS),)
 VERIFY_CANDIDATE_LIBRARY_ARGS := $(if $(REQUIRE_CANDIDATE_LIBRARY),--require-candidate-library,)
 VERIFY_EVIDENCE_CACHE_ARGS := $(if $(REQUIRE_EVIDENCE_CACHE),--require-evidence-cache,)
 
-.PHONY: research-package research-package-smoke research-package-pdf research-package-verify test-research-package
+.PHONY: research-package research-package-smoke research-package-cache-preflight research-package-pdf research-package-verify test-research-package
 
 research-package:
 	$(PYTHON) $(RUN_RESEARCH_PACKAGE) \
@@ -58,6 +63,15 @@ research-package-smoke:
 		MIN_VERIFIED_ROWS=$(SMOKE_MIN_VERIFIED_ROWS) \
 		TOP_K=$(SMOKE_TOP_K) \
 		EXTRA_RUN_ARGS="--max-rows $(SMOKE_MAX_ROWS)"
+
+research-package-cache-preflight:
+	$(PYTHON) $(RUN_EVIDENCE_CACHE_PREFLIGHT) \
+		--input $(SOURCE_TABLE) \
+		--dataset-id $(DATASET_ID) \
+		--source-name $(notdir $(basename $(SOURCE_TABLE))) \
+		--cache-dir $(EVIDENCE_CACHE_DIR) \
+		--output-dir $(CACHE_PREFLIGHT_DIR) \
+		$(CACHE_PREFLIGHT_MAX_ROWS_ARGS)
 
 research-package-pdf:
 	@command -v pandoc >/dev/null 2>&1 || { echo "pandoc is required for research-package-pdf. Install pandoc and rerun this target." >&2; exit 127; }
@@ -89,6 +103,7 @@ research-package-verify:
 test-research-package:
 	PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 $(PYTHON) -m pytest -q \
 		tests/test_canonical_make_targets.py \
+		tests/test_evidence_cache_preflight.py \
 		tests/test_research_package_runner.py \
 		tests/test_run_verified_discovery_cli.py \
 		tests/test_root_provenance_manifest.py

--- a/hybrid_agent_exploration/src/data/evidence_cache_preflight.py
+++ b/hybrid_agent_exploration/src/data/evidence_cache_preflight.py
@@ -1,0 +1,320 @@
+"""Plan external evidence-cache coverage before a verified discovery run.
+
+The preflight is intentionally read-only and does not call Crossref, PubChem,
+or any other network service. It answers whether an ``external-cached`` run can
+complete from existing JSON cache files, and which DOI or molecule keys still
+need evidence collection.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+
+EVIDENCE_CACHE_PREFLIGHT_SCHEMA_VERSION = "evidence-cache-preflight-v1"
+REFERENCE_CACHE_FILE = "reference_cache.json"
+MOLECULE_CACHE_FILE = "molecule_cache.json"
+
+
+@dataclass(frozen=True)
+class EvidenceCachePreflightArtifacts:
+    """Paths emitted by an evidence-cache preflight run."""
+
+    output_dir: Path
+    summary_json: Path
+    requirements_csv: Path
+    report_md: Path
+
+
+def summarize_evidence_cache_preflight(
+    df: pd.DataFrame,
+    *,
+    dataset_id: str,
+    source_name: str,
+    cache_dir: str | Path,
+    max_rows: int | None = None,
+) -> dict[str, Any]:
+    """Summarize required DOI and molecule cache keys for a source table."""
+
+    cache_root = Path(cache_dir)
+    reference_items, reference_uncacheable = _collect_reference_requirements(df)
+    molecule_items, molecule_uncacheable = _collect_molecule_requirements(df)
+    reference_cache = _load_cache(cache_root / REFERENCE_CACHE_FILE)
+    molecule_cache = _load_cache(cache_root / MOLECULE_CACHE_FILE)
+
+    requirements = _requirement_rows("reference", reference_items, reference_cache)
+    requirements.extend(_requirement_rows("molecule", molecule_items, molecule_cache))
+    reference_coverage = _coverage_summary(
+        cache_path=cache_root / REFERENCE_CACHE_FILE,
+        requirements=[row for row in requirements if row["entity_type"] == "reference"],
+        uncacheable_row_count=reference_uncacheable,
+    )
+    molecule_coverage = _coverage_summary(
+        cache_path=cache_root / MOLECULE_CACHE_FILE,
+        requirements=[row for row in requirements if row["entity_type"] == "molecule"],
+        uncacheable_row_count=molecule_uncacheable,
+    )
+    return {
+        "schema_version": EVIDENCE_CACHE_PREFLIGHT_SCHEMA_VERSION,
+        "dataset_id": dataset_id,
+        "source_name": source_name,
+        "generated_at": _now_iso(),
+        "network_access": "not_used",
+        "row_count": len(df),
+        "max_rows": max_rows,
+        "max_rows_is_smoke_only": max_rows is not None,
+        "cache_dir": str(cache_root),
+        "external_cache_ready": _positive_cache_complete(reference_coverage)
+        and _positive_cache_complete(molecule_coverage),
+        "all_positive_evidence_cached": reference_coverage["negative_cached_count"] == 0
+        and molecule_coverage["negative_cached_count"] == 0
+        and reference_coverage["missing_count"] == 0
+        and molecule_coverage["missing_count"] == 0,
+        "reference_cache": reference_coverage,
+        "molecule_cache": molecule_coverage,
+        "requirements": requirements,
+    }
+
+
+def write_evidence_cache_preflight_artifacts(
+    summary: dict[str, Any],
+    output_dir: str | Path,
+) -> EvidenceCachePreflightArtifacts:
+    """Write JSON, CSV, and Markdown evidence-cache preflight artifacts."""
+
+    root = Path(output_dir)
+    root.mkdir(parents=True, exist_ok=True)
+    artifacts = EvidenceCachePreflightArtifacts(
+        output_dir=root,
+        summary_json=root / "evidence_cache_preflight.json",
+        requirements_csv=root / "evidence_cache_requirements.csv",
+        report_md=root / "evidence_cache_preflight.md",
+    )
+    serializable = dict(summary)
+    serializable["outputs"] = {
+        "summary_json": artifacts.summary_json.name,
+        "requirements_csv": artifacts.requirements_csv.name,
+        "report_md": artifacts.report_md.name,
+    }
+    _write_json(serializable, artifacts.summary_json)
+    _write_requirements_csv(serializable["requirements"], artifacts.requirements_csv)
+    artifacts.report_md.write_text(_format_markdown(serializable), encoding="utf-8")
+    return artifacts
+
+
+def _collect_reference_requirements(df: pd.DataFrame) -> tuple[dict[str, list[str]], int]:
+    items: dict[str, list[str]] = {}
+    uncacheable = 0
+    for index, record in enumerate(df.to_dict(orient="records")):
+        key = _normalize_doi(record.get("doi"))
+        if not key:
+            uncacheable += 1
+            continue
+        items.setdefault(key, []).append(_record_id(record, index))
+    return items, uncacheable
+
+
+def _collect_molecule_requirements(df: pd.DataFrame) -> tuple[dict[str, list[str]], int]:
+    items: dict[str, list[str]] = {}
+    uncacheable = 0
+    for index, record in enumerate(df.to_dict(orient="records")):
+        key = _molecule_cache_key(record)
+        if not key:
+            uncacheable += 1
+            continue
+        items.setdefault(key, []).append(_record_id(record, index))
+    return items, uncacheable
+
+
+def _requirement_rows(
+    entity_type: str,
+    items: dict[str, list[str]],
+    cache: dict[str, Any],
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for key in sorted(items):
+        cache_status = _cache_status(key, cache)
+        rows.append(
+            {
+                "entity_type": entity_type,
+                "key": key,
+                "row_count": len(items[key]),
+                "record_ids": items[key],
+                "cache_status": cache_status,
+                "is_cached": cache_status in {"positive", "negative"},
+                "has_positive_evidence": cache_status == "positive",
+            }
+        )
+    return rows
+
+
+def _coverage_summary(
+    *,
+    cache_path: Path,
+    requirements: list[dict[str, Any]],
+    uncacheable_row_count: int,
+) -> dict[str, Any]:
+    required_count = len(requirements)
+    cached_count = sum(1 for row in requirements if row["is_cached"])
+    positive_cached_count = sum(1 for row in requirements if row["cache_status"] == "positive")
+    negative_cached_count = sum(1 for row in requirements if row["cache_status"] == "negative")
+    missing = [row["key"] for row in requirements if row["cache_status"] == "missing"]
+    return {
+        "cache_path": str(cache_path),
+        "cache_exists": cache_path.is_file(),
+        "required_count": required_count,
+        "cached_count": cached_count,
+        "positive_cached_count": positive_cached_count,
+        "negative_cached_count": negative_cached_count,
+        "missing_count": len(missing),
+        "uncacheable_row_count": uncacheable_row_count,
+        "cache_hit_fraction": _fraction(cached_count, required_count),
+        "positive_evidence_fraction": _fraction(positive_cached_count, required_count),
+        "missing_keys": missing,
+    }
+
+
+def _positive_cache_complete(summary: dict[str, Any]) -> bool:
+    return summary["missing_count"] == 0 and summary["negative_cached_count"] == 0
+
+
+def _load_cache(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Evidence cache must be a JSON object: {path}")
+    return payload
+
+
+def _cache_status(key: str, cache: dict[str, Any]) -> str:
+    if key not in cache:
+        return "missing"
+    return "positive" if cache[key] else "negative"
+
+
+def _write_requirements_csv(requirements: list[dict[str, Any]], path: Path) -> None:
+    rows = []
+    for row in requirements:
+        output = dict(row)
+        output["record_ids"] = ";".join(row["record_ids"])
+        output["record_ids_json"] = json.dumps(row["record_ids"], ensure_ascii=False)
+        rows.append(output)
+    columns = [
+        "entity_type",
+        "key",
+        "row_count",
+        "cache_status",
+        "is_cached",
+        "has_positive_evidence",
+        "record_ids",
+        "record_ids_json",
+    ]
+    pd.DataFrame(rows, columns=columns).to_csv(path, index=False)
+
+
+def _format_markdown(summary: dict[str, Any]) -> str:
+    reference = summary["reference_cache"]
+    molecule = summary["molecule_cache"]
+    lines = [
+        "# External Evidence Cache Preflight",
+        "",
+        f"- Dataset: `{summary['dataset_id']}`",
+        f"- Source: `{summary['source_name']}`",
+        f"- Rows scanned: {summary['row_count']}",
+        f"- Network access: `{summary['network_access']}`",
+        f"- Cache directory: `{summary['cache_dir']}`",
+        f"- External cache ready: `{summary['external_cache_ready']}`",
+        f"- All positive evidence cached: `{summary['all_positive_evidence_cached']}`",
+        "",
+        "## Reference cache coverage",
+        "",
+        _coverage_line(reference),
+        "",
+        "## Molecule cache coverage",
+        "",
+        _coverage_line(molecule),
+        "",
+        "## Missing Keys",
+        "",
+    ]
+    lines.extend(_missing_lines("Reference", reference["missing_keys"]))
+    lines.extend(_missing_lines("Molecule", molecule["missing_keys"]))
+    return "\n".join(lines) + "\n"
+
+
+def _coverage_line(summary: dict[str, Any]) -> str:
+    return (
+        f"- Required: {summary['required_count']}; cached: {summary['cached_count']}; "
+        f"positive: {summary['positive_cached_count']}; negative: {summary['negative_cached_count']}; "
+        f"missing: {summary['missing_count']}; uncacheable rows: {summary['uncacheable_row_count']}."
+    )
+
+
+def _missing_lines(label: str, keys: list[str]) -> list[str]:
+    if not keys:
+        return [f"- {label}: none"]
+    return [f"- {label}: `{key}`" for key in keys]
+
+
+def _normalize_doi(value: Any) -> str:
+    return _clean_text(value).lower()
+
+
+def _molecule_cache_key(record: dict[str, Any]) -> str:
+    pubchem_id = _normalize_pubchem_id(record.get("pubchem_id"))
+    if pubchem_id:
+        return f"pubchem:{pubchem_id}"
+    smiles = _clean_text(record.get("smiles"))
+    if smiles:
+        return f"smiles:{smiles}"
+    return ""
+
+
+def _normalize_pubchem_id(value: Any) -> str:
+    text = _clean_text(value)
+    if not text:
+        return ""
+    try:
+        parsed = float(text)
+    except ValueError:
+        return text
+    if math.isnan(parsed):
+        return ""
+    if parsed.is_integer():
+        return str(int(parsed))
+    return text
+
+
+def _record_id(record: dict[str, Any], zero_based_index: int) -> str:
+    text = _clean_text(record.get("record_id"))
+    return text or f"source_row_{zero_based_index + 1:06d}"
+
+
+def _clean_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, float) and math.isnan(value):
+        return ""
+    return str(value).strip()
+
+
+def _fraction(numerator: int, denominator: int) -> float:
+    if denominator == 0:
+        return 1.0
+    return round(numerator / denominator, 6)
+
+
+def _write_json(payload: dict[str, Any], path: Path) -> None:
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()

--- a/hybrid_agent_exploration/src/data/evidence_cache_preflight.py
+++ b/hybrid_agent_exploration/src/data/evidence_cache_preflight.py
@@ -318,8 +318,11 @@ def _record_id(record: dict[str, Any], zero_based_index: int) -> str:
 def _clean_text(value: Any) -> str:
     if value is None:
         return ""
-    if isinstance(value, float) and math.isnan(value):
-        return ""
+    try:
+        if pd.isna(value):
+            return ""
+    except (TypeError, ValueError):
+        pass
     return str(value).strip()
 
 

--- a/hybrid_agent_exploration/src/data/evidence_cache_preflight.py
+++ b/hybrid_agent_exploration/src/data/evidence_cache_preflight.py
@@ -21,6 +21,7 @@ import pandas as pd
 EVIDENCE_CACHE_PREFLIGHT_SCHEMA_VERSION = "evidence-cache-preflight-v1"
 REFERENCE_CACHE_FILE = "reference_cache.json"
 MOLECULE_CACHE_FILE = "molecule_cache.json"
+MAX_MARKDOWN_MISSING_KEYS = 50
 
 
 @dataclass(frozen=True)
@@ -145,6 +146,7 @@ def _requirement_rows(
             {
                 "entity_type": entity_type,
                 "key": key,
+                "key_source": _key_source(entity_type, key),
                 "row_count": len(items[key]),
                 "record_ids": items[key],
                 "cache_status": cache_status,
@@ -210,6 +212,7 @@ def _write_requirements_csv(requirements: list[dict[str, Any]], path: Path) -> N
     columns = [
         "entity_type",
         "key",
+        "key_source",
         "row_count",
         "cache_status",
         "is_cached",
@@ -261,7 +264,21 @@ def _coverage_line(summary: dict[str, Any]) -> str:
 def _missing_lines(label: str, keys: list[str]) -> list[str]:
     if not keys:
         return [f"- {label}: none"]
-    return [f"- {label}: `{key}`" for key in keys]
+    lines = [f"- {label}: `{key}`" for key in keys[:MAX_MARKDOWN_MISSING_KEYS]]
+    remaining = len(keys) - MAX_MARKDOWN_MISSING_KEYS
+    if remaining > 0:
+        lines.append(f"- {label}: {remaining} more keys omitted from Markdown; see `evidence_cache_requirements.csv`.")
+    return lines
+
+
+def _key_source(entity_type: str, key: str) -> str:
+    if entity_type == "reference":
+        return "doi"
+    if key.startswith("pubchem:"):
+        return "pubchem_id"
+    if key.startswith("smiles:"):
+        return "smiles"
+    return "unknown"
 
 
 def _normalize_doi(value: Any) -> str:

--- a/hybrid_agent_exploration/src/run_evidence_cache_preflight.py
+++ b/hybrid_agent_exploration/src/run_evidence_cache_preflight.py
@@ -1,0 +1,57 @@
+"""CLI for planning external evidence-cache coverage.
+
+This command is a read-only preflight: it inspects the source table and existing
+``reference_cache.json`` / ``molecule_cache.json`` files without calling any
+external service. Use it before a full ``external-cached`` research package run
+to determine how many DOI and molecule identities still need cache collection.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from data.evidence_cache_preflight import (
+    summarize_evidence_cache_preflight,
+    write_evidence_cache_preflight_artifacts,
+)
+from run_verified_discovery import default_cache_dir, load_input
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, help="CSV/XLSX source table to scan.")
+    parser.add_argument("--dataset-id", required=True, help="Stable dataset/run identifier.")
+    parser.add_argument("--source-name", help="Human-readable source table name; defaults to input file stem.")
+    parser.add_argument(
+        "--cache-dir",
+        help="Evidence cache directory; defaults to hybrid_agent_exploration/.cache/verified_discovery/<dataset-id>/evidence_cache.",
+    )
+    parser.add_argument("--output-dir", required=True, help="Directory for preflight JSON/CSV/Markdown artifacts.")
+    parser.add_argument("--max-rows", type=int, help="Optional input row cap for quick preflight smoke runs.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    input_path = Path(args.input)
+    cache_dir = Path(args.cache_dir) if args.cache_dir else default_cache_dir(args.dataset_id)
+    df = load_input(input_path, max_rows=args.max_rows)
+    artifacts = write_evidence_cache_preflight_artifacts(
+        summarize_evidence_cache_preflight(
+            df,
+            dataset_id=args.dataset_id,
+            source_name=args.source_name or input_path.stem,
+            cache_dir=cache_dir,
+            max_rows=args.max_rows,
+        ),
+        args.output_dir,
+    )
+    print(f"[evidence-cache-preflight] summary={artifacts.summary_json}")
+    print(f"[evidence-cache-preflight] requirements={artifacts.requirements_csv}")
+    print(f"[evidence-cache-preflight] report={artifacts.report_md}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_canonical_make_targets.py
+++ b/tests/test_canonical_make_targets.py
@@ -30,6 +30,7 @@ def test_canonical_research_package_targets_are_declared():
         "research-package",
         "research-package-smoke",
         "research-package-cache-preflight",
+        "research-package-cache-preflight-smoke",
         "research-package-pdf",
         "research-package-verify",
         "test-research-package",
@@ -71,14 +72,30 @@ def test_smoke_target_dry_run_caps_rows_in_ignored_artifact_dir():
     assert "hybrid_agent_exploration/results/verified_discovery_runs/" in output
 
 
-def test_cache_preflight_target_dry_run_uses_source_table_cache_and_artifact_dir():
+def test_cache_preflight_target_dry_run_scans_full_table_by_default():
+    output = _make_dry_run(
+        "research-package-cache-preflight",
+        SOURCE_TABLE="/tmp/source.csv",
+        DATASET_ID="unit-dataset",
+        ARTIFACT_DIR="/tmp/artifacts",
+    )
+
+    assert "hybrid_agent_exploration/src/run_evidence_cache_preflight.py" in output
+    assert "--input /tmp/source.csv" in output
+    assert "--dataset-id unit-dataset" in output
+    assert "--output-dir /tmp/artifacts/evidence_cache_preflight" in output
+    assert "--cache-dir" not in output
+    assert "--max-rows" not in output
+
+
+def test_cache_preflight_target_accepts_explicit_cache_dir_and_row_cap():
     output = _make_dry_run(
         "research-package-cache-preflight",
         SOURCE_TABLE="/tmp/source.csv",
         DATASET_ID="unit-dataset",
         ARTIFACT_DIR="/tmp/artifacts",
         EVIDENCE_CACHE_DIR="/tmp/cache",
-        SMOKE_MAX_ROWS="25",
+        CACHE_PREFLIGHT_MAX_ROWS="25",
     )
 
     assert "hybrid_agent_exploration/src/run_evidence_cache_preflight.py" in output
@@ -87,6 +104,17 @@ def test_cache_preflight_target_dry_run_uses_source_table_cache_and_artifact_dir
     assert "--cache-dir /tmp/cache" in output
     assert "--output-dir /tmp/artifacts/evidence_cache_preflight" in output
     assert "--max-rows 25" in output
+
+
+def test_cache_preflight_smoke_target_dry_run_caps_rows_explicitly():
+    output = _make_dry_run(
+        "research-package-cache-preflight-smoke",
+        SOURCE_TABLE="/tmp/source.csv",
+        CACHE_PREFLIGHT_SMOKE_MAX_ROWS="25",
+    )
+
+    assert "research-package-cache-preflight" in output
+    assert "CACHE_PREFLIGHT_MAX_ROWS=25" in output
 
 
 def test_pdf_target_dry_run_checks_pandoc_and_exports_report_pdfs():

--- a/tests/test_canonical_make_targets.py
+++ b/tests/test_canonical_make_targets.py
@@ -29,6 +29,7 @@ def test_canonical_research_package_targets_are_declared():
     for target in (
         "research-package",
         "research-package-smoke",
+        "research-package-cache-preflight",
         "research-package-pdf",
         "research-package-verify",
         "test-research-package",
@@ -70,6 +71,24 @@ def test_smoke_target_dry_run_caps_rows_in_ignored_artifact_dir():
     assert "hybrid_agent_exploration/results/verified_discovery_runs/" in output
 
 
+def test_cache_preflight_target_dry_run_uses_source_table_cache_and_artifact_dir():
+    output = _make_dry_run(
+        "research-package-cache-preflight",
+        SOURCE_TABLE="/tmp/source.csv",
+        DATASET_ID="unit-dataset",
+        ARTIFACT_DIR="/tmp/artifacts",
+        EVIDENCE_CACHE_DIR="/tmp/cache",
+        SMOKE_MAX_ROWS="25",
+    )
+
+    assert "hybrid_agent_exploration/src/run_evidence_cache_preflight.py" in output
+    assert "--input /tmp/source.csv" in output
+    assert "--dataset-id unit-dataset" in output
+    assert "--cache-dir /tmp/cache" in output
+    assert "--output-dir /tmp/artifacts/evidence_cache_preflight" in output
+    assert "--max-rows 25" in output
+
+
 def test_pdf_target_dry_run_checks_pandoc_and_exports_report_pdfs():
     output = _make_dry_run("research-package-pdf", ARTIFACT_DIR="/tmp/artifacts")
 
@@ -105,6 +124,7 @@ def test_test_research_package_target_runs_canonical_pytest_slice():
 
     assert "PYTEST_DISABLE_PLUGIN_AUTOLOAD=1" in output
     assert "tests/test_canonical_make_targets.py" in output
+    assert "tests/test_evidence_cache_preflight.py" in output
     assert "tests/test_research_package_runner.py" in output
     assert "tests/test_run_verified_discovery_cli.py" in output
     assert "tests/test_root_provenance_manifest.py" in output

--- a/tests/test_evidence_cache_preflight.py
+++ b/tests/test_evidence_cache_preflight.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import sys
 from pathlib import Path
@@ -96,6 +97,10 @@ def _write_cache_files(cache_dir: Path) -> None:
     )
 
 
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
 def test_preflight_summarizes_required_external_cache_coverage(tmp_path):
     from data.evidence_cache_preflight import summarize_evidence_cache_preflight
 
@@ -183,14 +188,24 @@ def test_preflight_writes_json_csv_and_markdown_artifacts(tmp_path):
     assert "`smiles:CCO`" in report
 
 
-def test_preflight_cli_writes_artifacts_without_network_access(tmp_path):
+def test_preflight_cli_writes_artifacts_without_network_access(tmp_path, monkeypatch):
     from run_evidence_cache_preflight import main
+    import harness.authenticity as authenticity
 
     source_csv = tmp_path / "source.csv"
     cache_dir = tmp_path / "evidence_cache"
     output_dir = tmp_path / "preflight"
     _source_dataframe().to_csv(source_csv, index=False)
     _write_cache_files(cache_dir)
+    cache_fingerprints = {
+        path.name: (path.stat().st_mtime_ns, _sha256(path))
+        for path in (cache_dir / "reference_cache.json", cache_dir / "molecule_cache.json")
+    }
+
+    def fail_on_network(*args, **kwargs):
+        raise AssertionError("preflight must not call external network resolvers")
+
+    monkeypatch.setattr(authenticity.requests, "get", fail_on_network)
 
     exit_code = main(
         [
@@ -213,3 +228,7 @@ def test_preflight_cli_writes_artifacts_without_network_access(tmp_path):
     assert summary["network_access"] == "not_used"
     assert summary["reference_cache"]["missing_count"] == 1
     assert summary["molecule_cache"]["missing_count"] == 1
+    assert {
+        path.name: (path.stat().st_mtime_ns, _sha256(path))
+        for path in (cache_dir / "reference_cache.json", cache_dir / "molecule_cache.json")
+    } == cache_fingerprints

--- a/tests/test_evidence_cache_preflight.py
+++ b/tests/test_evidence_cache_preflight.py
@@ -1,0 +1,215 @@
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1] / "hybrid_agent_exploration"
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+
+def _source_dataframe() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "record_id": "row-001",
+                "doi": "10.1021/ACS.JPCLETT.6C00119",
+                "title": "Verified PSC additive paper",
+                "smiles": "[Ba+2]",
+                "pubchem_id": "104810.0",
+                "cas_number": "22541-12-4",
+            },
+            {
+                "record_id": "row-002",
+                "doi": "10.1021/acs.jpclett.6c00119",
+                "title": "Duplicate DOI and CID",
+                "smiles": "[Ba+2]",
+                "pubchem_id": "104810",
+                "cas_number": "22541-12-4",
+            },
+            {
+                "record_id": "row-003",
+                "doi": "10.1038/s41586-026-00001-1",
+                "title": "Negative cached reference",
+                "smiles": "CCO",
+                "pubchem_id": "",
+                "cas_number": "64-17-5",
+            },
+            {
+                "record_id": "row-004",
+                "doi": "10.1126/science.abd0001",
+                "title": "Missing reference cache entry",
+                "smiles": "CCO",
+                "pubchem_id": "",
+                "cas_number": "64-17-5",
+            },
+            {
+                "record_id": "row-005",
+                "doi": "",
+                "title": "Uncacheable row",
+                "smiles": "",
+                "pubchem_id": "",
+                "cas_number": "",
+            },
+        ]
+    )
+
+
+def _write_cache_files(cache_dir: Path) -> None:
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "reference_cache.json").write_text(
+        json.dumps(
+            {
+                "10.1021/acs.jpclett.6c00119": {
+                    "kind": "reference",
+                    "source": "crossref",
+                    "doi": "10.1021/acs.jpclett.6c00119",
+                    "title": "Verified PSC additive paper",
+                    "year": 2026,
+                    "journal": "Journal of Physical Chemistry Letters",
+                    "url": "https://doi.org/10.1021/acs.jpclett.6c00119",
+                },
+                "10.1038/s41586-026-00001-1": None,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (cache_dir / "molecule_cache.json").write_text(
+        json.dumps(
+            {
+                "pubchem:104810": {
+                    "kind": "molecule",
+                    "source": "pubchem",
+                    "smiles": "[Ba+2]",
+                    "pubchem_id": "104810",
+                    "cas_number": "22541-12-4",
+                    "url": "https://pubchem.ncbi.nlm.nih.gov/compound/104810",
+                }
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_preflight_summarizes_required_external_cache_coverage(tmp_path):
+    from data.evidence_cache_preflight import summarize_evidence_cache_preflight
+
+    cache_dir = tmp_path / "evidence_cache"
+    _write_cache_files(cache_dir)
+
+    summary = summarize_evidence_cache_preflight(
+        _source_dataframe(),
+        dataset_id="cache-preflight-fixture",
+        source_name="fixture-source",
+        cache_dir=cache_dir,
+    )
+
+    assert summary["schema_version"] == "evidence-cache-preflight-v1"
+    assert summary["dataset_id"] == "cache-preflight-fixture"
+    assert summary["source_name"] == "fixture-source"
+    assert summary["cache_dir"] == str(cache_dir)
+    assert summary["row_count"] == 5
+    assert summary["external_cache_ready"] is False
+    assert summary["all_positive_evidence_cached"] is False
+
+    assert summary["reference_cache"]["required_count"] == 3
+    assert summary["reference_cache"]["cached_count"] == 2
+    assert summary["reference_cache"]["positive_cached_count"] == 1
+    assert summary["reference_cache"]["negative_cached_count"] == 1
+    assert summary["reference_cache"]["missing_count"] == 1
+    assert summary["reference_cache"]["uncacheable_row_count"] == 1
+    assert summary["reference_cache"]["missing_keys"] == ["10.1126/science.abd0001"]
+
+    assert summary["molecule_cache"]["required_count"] == 2
+    assert summary["molecule_cache"]["cached_count"] == 1
+    assert summary["molecule_cache"]["positive_cached_count"] == 1
+    assert summary["molecule_cache"]["negative_cached_count"] == 0
+    assert summary["molecule_cache"]["missing_count"] == 1
+    assert summary["molecule_cache"]["uncacheable_row_count"] == 1
+    assert summary["molecule_cache"]["missing_keys"] == ["smiles:CCO"]
+
+    assert summary["requirements"][0]["entity_type"] == "reference"
+    assert summary["requirements"][0]["key"] == "10.1021/acs.jpclett.6c00119"
+    assert summary["requirements"][0]["row_count"] == 2
+    assert summary["requirements"][0]["cache_status"] == "positive"
+    assert summary["requirements"][0]["record_ids"] == ["row-001", "row-002"]
+
+
+def test_preflight_writes_json_csv_and_markdown_artifacts(tmp_path):
+    from data.evidence_cache_preflight import (
+        summarize_evidence_cache_preflight,
+        write_evidence_cache_preflight_artifacts,
+    )
+
+    cache_dir = tmp_path / "evidence_cache"
+    _write_cache_files(cache_dir)
+    output_dir = tmp_path / "preflight"
+
+    artifacts = write_evidence_cache_preflight_artifacts(
+        summarize_evidence_cache_preflight(
+            _source_dataframe(),
+            dataset_id="cache-preflight-artifacts",
+            source_name="fixture-source",
+            cache_dir=cache_dir,
+        ),
+        output_dir,
+    )
+
+    assert artifacts.output_dir == output_dir
+    assert artifacts.summary_json == output_dir / "evidence_cache_preflight.json"
+    assert artifacts.requirements_csv == output_dir / "evidence_cache_requirements.csv"
+    assert artifacts.report_md == output_dir / "evidence_cache_preflight.md"
+
+    summary = json.loads(artifacts.summary_json.read_text(encoding="utf-8"))
+    assert summary["dataset_id"] == "cache-preflight-artifacts"
+    assert summary["outputs"]["summary_json"] == "evidence_cache_preflight.json"
+    assert summary["outputs"]["requirements_csv"] == "evidence_cache_requirements.csv"
+    assert summary["outputs"]["report_md"] == "evidence_cache_preflight.md"
+
+    requirements = pd.read_csv(artifacts.requirements_csv)
+    assert set(requirements["entity_type"]) == {"reference", "molecule"}
+    assert "cache_status" in requirements.columns
+    assert requirements.loc[requirements["key"] == "smiles:CCO", "cache_status"].item() == "missing"
+
+    report = artifacts.report_md.read_text(encoding="utf-8")
+    assert "# External Evidence Cache Preflight" in report
+    assert "Reference cache coverage" in report
+    assert "Molecule cache coverage" in report
+    assert "`smiles:CCO`" in report
+
+
+def test_preflight_cli_writes_artifacts_without_network_access(tmp_path):
+    from run_evidence_cache_preflight import main
+
+    source_csv = tmp_path / "source.csv"
+    cache_dir = tmp_path / "evidence_cache"
+    output_dir = tmp_path / "preflight"
+    _source_dataframe().to_csv(source_csv, index=False)
+    _write_cache_files(cache_dir)
+
+    exit_code = main(
+        [
+            "--input",
+            str(source_csv),
+            "--dataset-id",
+            "cache-preflight-cli",
+            "--source-name",
+            "fixture-source",
+            "--cache-dir",
+            str(cache_dir),
+            "--output-dir",
+            str(output_dir),
+        ]
+    )
+
+    assert exit_code == 0
+    summary = json.loads((output_dir / "evidence_cache_preflight.json").read_text(encoding="utf-8"))
+    assert summary["dataset_id"] == "cache-preflight-cli"
+    assert summary["network_access"] == "not_used"
+    assert summary["reference_cache"]["missing_count"] == 1
+    assert summary["molecule_cache"]["missing_count"] == 1


### PR DESCRIPTION
## Summary
- add a read-only external evidence cache preflight planner for DOI and molecule cache coverage
- add a CLI and Makefile targets for full-source and explicit smoke preflight runs
- add pytest coverage for cache key normalization, artifact outputs, no-network/no-cache-write behavior, and Makefile contracts

## Verification
- RED: PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --with pytest python -m pytest -q tests/test_evidence_cache_preflight.py tests/test_canonical_make_targets.py failed with missing module/CLI/target before implementation
- GREEN: PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --with pytest python -m pytest -q tests/test_evidence_cache_preflight.py tests/test_evidence_cache_verifiers.py tests/test_run_verified_discovery_cli.py tests/test_research_package_runner.py tests/test_research_package_contract.py tests/test_canonical_make_targets.py -> 37 passed
- Lint: uv run --with ruff ruff check hybrid_agent_exploration/src/data/evidence_cache_preflight.py hybrid_agent_exploration/src/run_evidence_cache_preflight.py tests/test_evidence_cache_preflight.py tests/test_canonical_make_targets.py -> All checks passed
- Real full-source preflight: make research-package-cache-preflight PYTHON="uv run python" SOURCE_TABLE=/share/yhm/test/20260216_with_chemical_merge_fast/merged_llm_crossref_data_streaming_with_chemical_data_fast.xlsx DATASET_ID=psc-additive-closure-full-source-columns-full-preflight ARTIFACT_DIR=hybrid_agent_exploration/results/verified_discovery_runs/psc-additive-closure-full-source-columns-full-preflight CACHE_PREFLIGHT_MAX_ROWS= -> 91,357 rows scanned; 43,279 DOI keys and 3,536 molecule keys required; caches missing

## Scientific note
This does not claim publication-grade closure. It creates the preflight evidence needed before the next PR can safely build full external Crossref/PubChem caches.