### PR TITLE
feat: add resumable evidence cache collector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,15 +13,20 @@ SMOKE_TOP_K ?= 10
 CACHE_PREFLIGHT_MAX_ROWS ?=
 CACHE_PREFLIGHT_SMOKE_MAX_ROWS ?= $(SMOKE_MAX_ROWS)
 EVIDENCE_CACHE_DIR ?=
+CACHE_COLLECT_MAX_REQUESTS ?= 100
+CACHE_COLLECT_RETRY_ATTEMPTS ?= 2
 PANDOC_PDF_ENGINE ?= xelatex
 PANDOC_MAINFONT ?= DejaVu Serif
 
 RUN_RESEARCH_PACKAGE := hybrid_agent_exploration/src/run_research_package.py
 RUN_EVIDENCE_CACHE_PREFLIGHT := hybrid_agent_exploration/src/run_evidence_cache_preflight.py
+RUN_EVIDENCE_CACHE_COLLECTOR := hybrid_agent_exploration/src/run_evidence_cache_collector.py
 ROOT_PROVENANCE_MANIFEST := hybrid_agent_exploration/src/reporting/root_provenance_manifest.py
 VERIFY_RESEARCH_PACKAGE := hybrid_agent_exploration/src/verify_research_package.py
 VERIFIED_DISCOVERY_DIR := $(ARTIFACT_DIR)/verified_discovery
 CACHE_PREFLIGHT_DIR := $(ARTIFACT_DIR)/evidence_cache_preflight
+CACHE_REQUIREMENTS_CSV := $(CACHE_PREFLIGHT_DIR)/evidence_cache_requirements.csv
+CACHE_COLLECTION_REPORT := $(ARTIFACT_DIR)/evidence_cache_collection_report.json
 REPORT_DIR := $(ARTIFACT_DIR)/report_bundle/main_text
 SI_DIR := $(ARTIFACT_DIR)/report_bundle/si
 CANDIDATE_LIBRARY_DIR := $(ARTIFACT_DIR)/candidate_library
@@ -39,10 +44,11 @@ CANDIDATE_SOURCE_ARGS := $(if $(CANDIDATE_SOURCE),--candidate-source $(CANDIDATE
 CANDIDATE_SOURCE_NAME_ARGS := $(if $(CANDIDATE_SOURCE_NAME),--candidate-source-name $(CANDIDATE_SOURCE_NAME),)
 CACHE_PREFLIGHT_CACHE_DIR_ARGS := $(if $(EVIDENCE_CACHE_DIR),--cache-dir $(EVIDENCE_CACHE_DIR),)
 CACHE_PREFLIGHT_MAX_ROWS_ARGS := $(if $(CACHE_PREFLIGHT_MAX_ROWS),--max-rows $(CACHE_PREFLIGHT_MAX_ROWS),)
+CACHE_COLLECT_CACHE_DIR_ARGS := $(if $(EVIDENCE_CACHE_DIR),--cache-dir $(EVIDENCE_CACHE_DIR),)
 VERIFY_CANDIDATE_LIBRARY_ARGS := $(if $(REQUIRE_CANDIDATE_LIBRARY),--require-candidate-library,)
 VERIFY_EVIDENCE_CACHE_ARGS := $(if $(REQUIRE_EVIDENCE_CACHE),--require-evidence-cache,)
 
-.PHONY: research-package research-package-smoke research-package-cache-preflight research-package-cache-preflight-smoke research-package-pdf research-package-verify test-research-package
+.PHONY: research-package research-package-smoke research-package-cache-preflight research-package-cache-preflight-smoke research-package-cache-collect research-package-cache-collect-dry-run research-package-pdf research-package-verify test-research-package
 
 research-package:
 	$(PYTHON) $(RUN_RESEARCH_PACKAGE) \
@@ -79,6 +85,20 @@ research-package-cache-preflight-smoke:
 	$(MAKE) research-package-cache-preflight \
 		CACHE_PREFLIGHT_MAX_ROWS=$(CACHE_PREFLIGHT_SMOKE_MAX_ROWS)
 
+research-package-cache-collect:
+	$(PYTHON) $(RUN_EVIDENCE_CACHE_COLLECTOR) \
+		--requirements-csv $(CACHE_REQUIREMENTS_CSV) \
+		--dataset-id $(DATASET_ID) \
+		--max-requests $(CACHE_COLLECT_MAX_REQUESTS) \
+		--retry-attempts $(CACHE_COLLECT_RETRY_ATTEMPTS) \
+		--output-json $(CACHE_COLLECTION_REPORT) \
+		$(CACHE_COLLECT_CACHE_DIR_ARGS) \
+		$(EXTRA_CACHE_COLLECT_ARGS)
+
+research-package-cache-collect-dry-run:
+	$(MAKE) research-package-cache-collect \
+		EXTRA_CACHE_COLLECT_ARGS=--dry-run
+
 research-package-pdf:
 	@command -v pandoc >/dev/null 2>&1 || { echo "pandoc is required for research-package-pdf. Install pandoc and rerun this target." >&2; exit 127; }
 	@test -f $(MAIN_TEXT_MD) || { echo "missing main text markdown: $(MAIN_TEXT_MD). Run make research-package first or set ARTIFACT_DIR." >&2; exit 2; }
@@ -109,6 +129,7 @@ research-package-verify:
 test-research-package:
 	PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 $(PYTHON) -m pytest -q \
 		tests/test_canonical_make_targets.py \
+		tests/test_evidence_cache_collector.py \
 		tests/test_evidence_cache_preflight.py \
 		tests/test_research_package_runner.py \
 		tests/test_run_verified_discovery_cli.py \

--- a/hybrid_agent_exploration/src/data/evidence_cache_collector.py
+++ b/hybrid_agent_exploration/src/data/evidence_cache_collector.py
@@ -42,6 +42,7 @@ def collect_evidence_cache(
     dry_run: bool = False,
     retry_attempts: int = 1,
     include_smiles: bool = False,
+    write_negative_cache: bool = False,
 ) -> dict[str, Any]:
     """Fill missing cache entries with a bounded, resumable collection run."""
 
@@ -69,10 +70,12 @@ def collect_evidence_cache(
         "entity_type": entity_type,
         "max_requests": max_requests,
         "retry_attempts": retry_attempts,
+        "write_negative_cache": write_negative_cache,
         "planned_count": len(planned),
         "attempted_count": 0,
         "positive_written_count": 0,
         "negative_written_count": 0,
+        "no_evidence_count": 0,
         "error_count": 0,
         "unsupported_count": len(unsupported),
         "skipped_existing_count": len(requirements) - len(missing),
@@ -95,16 +98,20 @@ def collect_evidence_cache(
             if error is not None:
                 _record_error(summary, requirement, error)
                 continue
-            reference_cache[requirement.key] = evidence.to_source() if evidence else None
-            _write_cache(reference_cache, reference_cache_path)
+            should_write_negative = write_negative_cache
+            if evidence or should_write_negative:
+                reference_cache[requirement.key] = evidence.to_source() if evidence else None
+                _write_cache(reference_cache, reference_cache_path)
         elif requirement.entity_type == "molecule":
             record = _molecule_record(requirement.key)
             evidence, error = _resolve_with_retry(lambda: molecule_resolver(record), retry_attempts)
             if error is not None:
                 _record_error(summary, requirement, error)
                 continue
-            molecule_cache[requirement.key] = evidence.to_source() if evidence else None
-            _write_cache(molecule_cache, molecule_cache_path)
+            should_write_negative = write_negative_cache and not _is_smiles_requirement(requirement)
+            if evidence or should_write_negative:
+                molecule_cache[requirement.key] = evidence.to_source() if evidence else None
+                _write_cache(molecule_cache, molecule_cache_path)
         else:
             raise ValueError(f"Unsupported entity_type: {requirement.entity_type}")
 
@@ -112,9 +119,12 @@ def collect_evidence_cache(
         if evidence:
             summary["positive_written_count"] += 1
             status = "positive"
-        else:
+        elif should_write_negative:
             summary["negative_written_count"] += 1
             status = "negative"
+        else:
+            summary["no_evidence_count"] += 1
+            status = "no_evidence"
         summary["processed"].append(
             {
                 "entity_type": requirement.entity_type,
@@ -242,6 +252,10 @@ def _molecule_record(key: str) -> dict[str, Any]:
     if key.startswith("smiles:"):
         return {"smiles": key.removeprefix("smiles:")}
     return {"smiles": key}
+
+
+def _is_smiles_requirement(requirement: CacheRequirement) -> bool:
+    return requirement.entity_type == "molecule" and requirement.key.startswith("smiles:")
 
 
 def _record_ids(record: dict[str, Any]) -> list[str]:

--- a/hybrid_agent_exploration/src/data/evidence_cache_collector.py
+++ b/hybrid_agent_exploration/src/data/evidence_cache_collector.py
@@ -1,0 +1,287 @@
+"""Collect missing external evidence cache entries from preflight requirements."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+import pandas as pd
+
+from harness.authenticity import MoleculeEvidence, ReferenceEvidence
+
+
+REFERENCE_CACHE_FILE = "reference_cache.json"
+MOLECULE_CACHE_FILE = "molecule_cache.json"
+ReferenceResolver = Callable[[str], ReferenceEvidence | None]
+MoleculeResolver = Callable[[dict[str, Any]], MoleculeEvidence | None]
+
+
+@dataclass(frozen=True)
+class CacheRequirement:
+    """One missing DOI or molecule cache key to resolve."""
+
+    entity_type: str
+    key: str
+    key_source: str
+    row_count: int
+    record_ids: list[str]
+
+
+def collect_evidence_cache(
+    *,
+    requirements_csv: str | Path,
+    cache_dir: str | Path,
+    max_requests: int,
+    reference_resolver: ReferenceResolver,
+    molecule_resolver: MoleculeResolver,
+    dataset_id: str | None = None,
+    entity_type: str = "all",
+    dry_run: bool = False,
+    retry_attempts: int = 1,
+    include_smiles: bool = False,
+) -> dict[str, Any]:
+    """Fill missing cache entries with a bounded, resumable collection run."""
+
+    if max_requests < 0:
+        raise ValueError("max_requests must be >= 0")
+    if retry_attempts < 1:
+        raise ValueError("retry_attempts must be >= 1")
+    cache_root = Path(cache_dir)
+    reference_cache_path = cache_root / REFERENCE_CACHE_FILE
+    molecule_cache_path = cache_root / MOLECULE_CACHE_FILE
+    reference_cache = _load_cache(reference_cache_path)
+    molecule_cache = _load_cache(molecule_cache_path)
+    requirements = _load_requirements(requirements_csv, entity_type=entity_type)
+    missing = _select_missing(requirements, reference_cache=reference_cache, molecule_cache=molecule_cache)
+    supported, unsupported = _split_supported(missing, include_smiles=include_smiles)
+    planned = supported[:max_requests]
+
+    summary = {
+        "schema_version": "evidence-cache-collector-v1",
+        "dataset_id": dataset_id,
+        "generated_at": _now_iso(),
+        "requirements_csv": str(Path(requirements_csv)),
+        "cache_dir": str(cache_root),
+        "dry_run": dry_run,
+        "entity_type": entity_type,
+        "max_requests": max_requests,
+        "retry_attempts": retry_attempts,
+        "planned_count": len(planned),
+        "attempted_count": 0,
+        "positive_written_count": 0,
+        "negative_written_count": 0,
+        "error_count": 0,
+        "unsupported_count": len(unsupported),
+        "skipped_existing_count": len(requirements) - len(missing),
+        "remaining_missing_count": len(missing),
+        "entity_type_counts": {},
+        "processed": [],
+        "errors": [],
+        "unsupported": [_requirement_summary(requirement) for requirement in unsupported],
+    }
+    if dry_run or max_requests == 0:
+        summary["remaining_missing_count"] = len(missing)
+        summary["entity_type_counts"] = _entity_counts(planned)
+        return summary
+
+    for requirement in planned:
+        evidence: ReferenceEvidence | MoleculeEvidence | None
+        error: str | None
+        if requirement.entity_type == "reference":
+            evidence, error = _resolve_with_retry(lambda: reference_resolver(requirement.key), retry_attempts)
+            if error is not None:
+                _record_error(summary, requirement, error)
+                continue
+            reference_cache[requirement.key] = evidence.to_source() if evidence else None
+            _write_cache(reference_cache, reference_cache_path)
+        elif requirement.entity_type == "molecule":
+            record = _molecule_record(requirement.key)
+            evidence, error = _resolve_with_retry(lambda: molecule_resolver(record), retry_attempts)
+            if error is not None:
+                _record_error(summary, requirement, error)
+                continue
+            molecule_cache[requirement.key] = evidence.to_source() if evidence else None
+            _write_cache(molecule_cache, molecule_cache_path)
+        else:
+            raise ValueError(f"Unsupported entity_type: {requirement.entity_type}")
+
+        summary["attempted_count"] += 1
+        if evidence:
+            summary["positive_written_count"] += 1
+            status = "positive"
+        else:
+            summary["negative_written_count"] += 1
+            status = "negative"
+        summary["processed"].append(
+            {
+                "entity_type": requirement.entity_type,
+                "key": requirement.key,
+                "cache_status": status,
+                "row_count": requirement.row_count,
+                "record_ids": requirement.record_ids,
+            }
+        )
+
+    remaining = _select_missing(requirements, reference_cache=reference_cache, molecule_cache=molecule_cache)
+    summary["remaining_missing_count"] = len(remaining)
+    summary["entity_type_counts"] = _entity_counts(summary["processed"])
+    return summary
+
+
+def write_collection_report(summary: dict[str, Any], output_path: str | Path) -> Path:
+    """Write the collector summary JSON."""
+
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(summary, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def _load_requirements(path: str | Path, *, entity_type: str) -> list[CacheRequirement]:
+    df = pd.read_csv(path)
+    requirements: list[CacheRequirement] = []
+    for record in df.to_dict(orient="records"):
+        current_entity = _text(record.get("entity_type"))
+        if entity_type != "all" and current_entity != entity_type:
+            continue
+        if _text(record.get("cache_status")) != "missing":
+            continue
+        requirements.append(
+            CacheRequirement(
+                entity_type=current_entity,
+                key=_text(record.get("key")),
+                key_source=_text(record.get("key_source")),
+                row_count=_int(record.get("row_count")),
+                record_ids=_record_ids(record),
+            )
+        )
+    return [requirement for requirement in requirements if requirement.key]
+
+
+def _select_missing(
+    requirements: Iterable[CacheRequirement],
+    *,
+    reference_cache: dict[str, Any],
+    molecule_cache: dict[str, Any],
+) -> list[CacheRequirement]:
+    selected: list[CacheRequirement] = []
+    for requirement in requirements:
+        cache = reference_cache if requirement.entity_type == "reference" else molecule_cache
+        if requirement.key not in cache:
+            selected.append(requirement)
+    return selected
+
+
+def _split_supported(
+    requirements: Iterable[CacheRequirement],
+    *,
+    include_smiles: bool,
+) -> tuple[list[CacheRequirement], list[CacheRequirement]]:
+    supported: list[CacheRequirement] = []
+    unsupported: list[CacheRequirement] = []
+    for requirement in requirements:
+        if requirement.entity_type != "molecule":
+            supported.append(requirement)
+            continue
+        if requirement.key.startswith("pubchem:") or include_smiles:
+            supported.append(requirement)
+        else:
+            unsupported.append(requirement)
+    return supported, unsupported
+
+
+def _resolve_with_retry(
+    resolver: Callable[[], ReferenceEvidence | MoleculeEvidence | None],
+    retry_attempts: int,
+) -> tuple[ReferenceEvidence | MoleculeEvidence | None, str | None]:
+    last_error: Exception | None = None
+    for _ in range(retry_attempts):
+        try:
+            return resolver(), None
+        except Exception as exc:  # noqa: BLE001 - report transient resolver failures without poisoning caches.
+            last_error = exc
+    assert last_error is not None
+    return None, str(last_error)
+
+
+def _record_error(summary: dict[str, Any], requirement: CacheRequirement, error: str) -> None:
+    summary["attempted_count"] += 1
+    summary["error_count"] += 1
+    summary["errors"].append({**_requirement_summary(requirement), "error": error})
+
+
+def _requirement_summary(requirement: CacheRequirement) -> dict[str, Any]:
+    return {
+        "entity_type": requirement.entity_type,
+        "key": requirement.key,
+        "row_count": requirement.row_count,
+        "record_ids": requirement.record_ids,
+    }
+
+
+def _load_cache(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Evidence cache must be a JSON object: {path}")
+    return payload
+
+
+def _write_cache(cache: dict[str, Any], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(cache, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _molecule_record(key: str) -> dict[str, Any]:
+    if key.startswith("pubchem:"):
+        return {"pubchem_id": key.removeprefix("pubchem:")}
+    if key.startswith("smiles:"):
+        return {"smiles": key.removeprefix("smiles:")}
+    return {"smiles": key}
+
+
+def _record_ids(record: dict[str, Any]) -> list[str]:
+    payload = _text(record.get("record_ids_json"))
+    if payload:
+        try:
+            parsed = json.loads(payload)
+        except json.JSONDecodeError:
+            parsed = []
+        if isinstance(parsed, list):
+            return [str(item) for item in parsed]
+    text = _text(record.get("record_ids"))
+    return [item for item in text.split(";") if item]
+
+
+def _entity_counts(items: Iterable[Any]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for item in items:
+        entity = item.entity_type if isinstance(item, CacheRequirement) else item["entity_type"]
+        counts[entity] = counts.get(entity, 0) + 1
+    return counts
+
+
+def _text(value: Any) -> str:
+    if value is None:
+        return ""
+    try:
+        if pd.isna(value):
+            return ""
+    except (TypeError, ValueError):
+        pass
+    return str(value).strip()
+
+
+def _int(value: Any) -> int:
+    text = _text(value)
+    if not text:
+        return 0
+    return int(float(text))
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()

--- a/hybrid_agent_exploration/src/run_evidence_cache_collector.py
+++ b/hybrid_agent_exploration/src/run_evidence_cache_collector.py
@@ -1,0 +1,57 @@
+"""CLI for bounded, resumable external evidence cache collection."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from data.evidence_cache_collector import collect_evidence_cache, write_collection_report
+from harness.authenticity import CrossrefReferenceVerifier, PubChemMoleculeVerifier
+from run_verified_discovery import default_cache_dir
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--requirements-csv", required=True, help="Preflight evidence_cache_requirements.csv.")
+    parser.add_argument("--dataset-id", required=True, help="Stable dataset/run identifier.")
+    parser.add_argument(
+        "--cache-dir",
+        help="Evidence cache directory; defaults to hybrid_agent_exploration/.cache/verified_discovery/<dataset-id>/evidence_cache.",
+    )
+    parser.add_argument("--max-requests", type=int, required=True, help="Maximum resolver calls for this batch.")
+    parser.add_argument("--output-json", required=True, help="Collector report JSON path.")
+    parser.add_argument("--entity-type", choices=("all", "reference", "molecule"), default="all")
+    parser.add_argument("--retry-attempts", type=int, default=2)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--include-smiles",
+        action="store_true",
+        help="Attempt smiles:<SMILES> molecule keys. Default is false because the current PubChem resolver is CID-backed.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    cache_dir = Path(args.cache_dir) if args.cache_dir else default_cache_dir(args.dataset_id)
+    summary = collect_evidence_cache(
+        requirements_csv=args.requirements_csv,
+        cache_dir=cache_dir,
+        dataset_id=args.dataset_id,
+        max_requests=args.max_requests,
+        entity_type=args.entity_type,
+        retry_attempts=args.retry_attempts,
+        dry_run=args.dry_run,
+        include_smiles=args.include_smiles,
+        reference_resolver=CrossrefReferenceVerifier(),
+        molecule_resolver=PubChemMoleculeVerifier(),
+    )
+    report_path = write_collection_report(summary, args.output_json)
+    print(f"[evidence-cache-collector] report={report_path}")
+    print(f"[evidence-cache-collector] attempted={summary['attempted_count']}")
+    print(f"[evidence-cache-collector] remaining_missing={summary['remaining_missing_count']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hybrid_agent_exploration/src/run_evidence_cache_collector.py
+++ b/hybrid_agent_exploration/src/run_evidence_cache_collector.py
@@ -24,6 +24,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--retry-attempts", type=int, default=2)
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument(
+        "--write-negative-cache",
+        action="store_true",
+        help="Persist resolver None results as negative cache entries. Default is false to avoid poisoning cache on swallowed transient failures.",
+    )
+    parser.add_argument(
         "--include-smiles",
         action="store_true",
         help="Attempt smiles:<SMILES> molecule keys. Default is false because the current PubChem resolver is CID-backed.",
@@ -43,6 +48,7 @@ def main(argv: list[str] | None = None) -> int:
         retry_attempts=args.retry_attempts,
         dry_run=args.dry_run,
         include_smiles=args.include_smiles,
+        write_negative_cache=args.write_negative_cache,
         reference_resolver=CrossrefReferenceVerifier(),
         molecule_resolver=PubChemMoleculeVerifier(),
     )

--- a/tests/test_canonical_make_targets.py
+++ b/tests/test_canonical_make_targets.py
@@ -31,6 +31,8 @@ def test_canonical_research_package_targets_are_declared():
         "research-package-smoke",
         "research-package-cache-preflight",
         "research-package-cache-preflight-smoke",
+        "research-package-cache-collect",
+        "research-package-cache-collect-dry-run",
         "research-package-pdf",
         "research-package-verify",
         "test-research-package",
@@ -117,6 +119,34 @@ def test_cache_preflight_smoke_target_dry_run_caps_rows_explicitly():
     assert "CACHE_PREFLIGHT_MAX_ROWS=25" in output
 
 
+def test_cache_collect_target_dry_run_uses_preflight_requirements_and_budget():
+    output = _make_dry_run(
+        "research-package-cache-collect",
+        DATASET_ID="unit-dataset",
+        ARTIFACT_DIR="/tmp/artifacts",
+        CACHE_COLLECT_MAX_REQUESTS="7",
+    )
+
+    assert "hybrid_agent_exploration/src/run_evidence_cache_collector.py" in output
+    assert "--requirements-csv /tmp/artifacts/evidence_cache_preflight/evidence_cache_requirements.csv" in output
+    assert "--dataset-id unit-dataset" in output
+    assert "--max-requests 7" in output
+    assert "--output-json /tmp/artifacts/evidence_cache_collection_report.json" in output
+    assert "--cache-dir" not in output
+    assert "--dry-run" not in output
+
+
+def test_cache_collect_dry_run_target_does_not_write_cache():
+    output = _make_dry_run(
+        "research-package-cache-collect-dry-run",
+        DATASET_ID="unit-dataset",
+        CACHE_COLLECT_MAX_REQUESTS="7",
+    )
+
+    assert "research-package-cache-collect" in output
+    assert "EXTRA_CACHE_COLLECT_ARGS=--dry-run" in output
+
+
 def test_pdf_target_dry_run_checks_pandoc_and_exports_report_pdfs():
     output = _make_dry_run("research-package-pdf", ARTIFACT_DIR="/tmp/artifacts")
 
@@ -152,6 +182,7 @@ def test_test_research_package_target_runs_canonical_pytest_slice():
 
     assert "PYTEST_DISABLE_PLUGIN_AUTOLOAD=1" in output
     assert "tests/test_canonical_make_targets.py" in output
+    assert "tests/test_evidence_cache_collector.py" in output
     assert "tests/test_evidence_cache_preflight.py" in output
     assert "tests/test_research_package_runner.py" in output
     assert "tests/test_run_verified_discovery_cli.py" in output

--- a/tests/test_evidence_cache_collector.py
+++ b/tests/test_evidence_cache_collector.py
@@ -138,11 +138,12 @@ def test_collector_resumes_missing_requirements_without_overwriting_existing_cac
         molecule_resolver=molecule_resolver,
     )
 
-    assert second["attempted_count"] == 2
+    assert second["attempted_count"] == 1
     assert second["positive_written_count"] == 1
-    assert second["negative_written_count"] == 1
-    assert second["remaining_missing_count"] == 0
-    assert molecule_calls == [{"pubchem_id": "104810"}, {"smiles": "CCO"}]
+    assert second["negative_written_count"] == 0
+    assert second["unsupported_count"] == 1
+    assert second["remaining_missing_count"] == 1
+    assert molecule_calls == [{"pubchem_id": "104810"}]
 
     reference_cache = json.loads((cache_dir / "reference_cache.json").read_text(encoding="utf-8"))
     molecule_cache = json.loads((cache_dir / "molecule_cache.json").read_text(encoding="utf-8"))
@@ -150,7 +151,7 @@ def test_collector_resumes_missing_requirements_without_overwriting_existing_cac
     assert reference_cache["10.1021/acs.jpclett.6c00119"]["source"] == "fixture-crossref"
     assert reference_cache["10.1038/s41586-026-00001-1"]["source"] == "fixture-crossref"
     assert molecule_cache["pubchem:104810"]["pubchem_id"] == "104810"
-    assert molecule_cache["smiles:CCO"] is None
+    assert "smiles:CCO" not in molecule_cache
 
 
 def test_collector_dry_run_does_not_write_cache_files(tmp_path):
@@ -177,6 +178,7 @@ def test_collector_dry_run_does_not_write_cache_files(tmp_path):
     assert summary["dry_run"] is True
     assert summary["attempted_count"] == 0
     assert summary["planned_count"] == 3
+    assert summary["unsupported_count"] == 1
     assert {
         path.name: path.read_text(encoding="utf-8")
         for path in (cache_dir / "reference_cache.json", cache_dir / "molecule_cache.json")
@@ -220,3 +222,61 @@ def test_collector_cli_writes_report_with_injected_resolvers(tmp_path, monkeypat
     assert report["dataset_id"] == "collector-cli"
     assert report["attempted_count"] == 1
     assert report["entity_type_counts"]["reference"] == 1
+
+
+def test_collector_retries_transient_errors_without_writing_negative_cache(tmp_path):
+    from data.evidence_cache_collector import collect_evidence_cache
+    from harness.authenticity import ReferenceEvidence
+
+    requirements = tmp_path / "requirements.csv"
+    cache_dir = tmp_path / "evidence_cache"
+    _requirements_csv(requirements)
+    _seed_caches(cache_dir)
+    attempts = []
+
+    def flaky_reference_resolver(doi):
+        attempts.append(doi)
+        if len(attempts) == 1:
+            raise RuntimeError("temporary crossref failure")
+        return ReferenceEvidence(doi=doi, title="Recovered reference", source="fixture-crossref")
+
+    summary = collect_evidence_cache(
+        requirements_csv=requirements,
+        cache_dir=cache_dir,
+        max_requests=1,
+        retry_attempts=2,
+        reference_resolver=flaky_reference_resolver,
+        molecule_resolver=lambda record: None,
+    )
+
+    assert attempts == ["10.1021/acs.jpclett.6c00119", "10.1021/acs.jpclett.6c00119"]
+    assert summary["attempted_count"] == 1
+    assert summary["error_count"] == 0
+    reference_cache = json.loads((cache_dir / "reference_cache.json").read_text(encoding="utf-8"))
+    assert reference_cache["10.1021/acs.jpclett.6c00119"]["title"] == "Recovered reference"
+
+
+def test_collector_does_not_write_negative_cache_after_retry_exhaustion(tmp_path):
+    from data.evidence_cache_collector import collect_evidence_cache
+
+    requirements = tmp_path / "requirements.csv"
+    cache_dir = tmp_path / "evidence_cache"
+    _requirements_csv(requirements)
+    _seed_caches(cache_dir)
+
+    def failing_reference_resolver(doi):
+        raise RuntimeError("rate limited")
+
+    summary = collect_evidence_cache(
+        requirements_csv=requirements,
+        cache_dir=cache_dir,
+        max_requests=1,
+        retry_attempts=2,
+        reference_resolver=failing_reference_resolver,
+        molecule_resolver=lambda record: None,
+    )
+
+    assert summary["attempted_count"] == 1
+    assert summary["error_count"] == 1
+    reference_cache = json.loads((cache_dir / "reference_cache.json").read_text(encoding="utf-8"))
+    assert "10.1021/acs.jpclett.6c00119" not in reference_cache

--- a/tests/test_evidence_cache_collector.py
+++ b/tests/test_evidence_cache_collector.py
@@ -1,0 +1,222 @@
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1] / "hybrid_agent_exploration"
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+
+def _requirements_csv(path: Path) -> None:
+    pd.DataFrame(
+        [
+            {
+                "entity_type": "reference",
+                "key": "10.1021/acs.jpclett.6c00119",
+                "key_source": "doi",
+                "cache_status": "missing",
+                "row_count": 2,
+                "record_ids": "row-001;row-002",
+                "record_ids_json": json.dumps(["row-001", "row-002"]),
+            },
+            {
+                "entity_type": "reference",
+                "key": "10.1038/s41586-026-00001-1",
+                "key_source": "doi",
+                "cache_status": "missing",
+                "row_count": 1,
+                "record_ids": "row-003",
+                "record_ids_json": json.dumps(["row-003"]),
+            },
+            {
+                "entity_type": "reference",
+                "key": "10.1126/science.cached",
+                "key_source": "doi",
+                "cache_status": "positive",
+                "row_count": 1,
+                "record_ids": "row-004",
+                "record_ids_json": json.dumps(["row-004"]),
+            },
+            {
+                "entity_type": "molecule",
+                "key": "pubchem:104810",
+                "key_source": "pubchem_id",
+                "cache_status": "missing",
+                "row_count": 2,
+                "record_ids": "row-001;row-002",
+                "record_ids_json": json.dumps(["row-001", "row-002"]),
+            },
+            {
+                "entity_type": "molecule",
+                "key": "smiles:CCO",
+                "key_source": "smiles",
+                "cache_status": "missing",
+                "row_count": 1,
+                "record_ids": "row-005",
+                "record_ids_json": json.dumps(["row-005"]),
+            },
+        ]
+    ).to_csv(path, index=False)
+
+
+def _seed_caches(cache_dir: Path) -> None:
+    cache_dir.mkdir(parents=True)
+    (cache_dir / "reference_cache.json").write_text(
+        json.dumps(
+            {
+                "10.1126/science.cached": {
+                    "kind": "reference",
+                    "source": "fixture-crossref",
+                    "doi": "10.1126/science.cached",
+                    "title": "Already cached",
+                }
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (cache_dir / "molecule_cache.json").write_text(
+        json.dumps({"smiles:cached": None}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_collector_resumes_missing_requirements_without_overwriting_existing_cache(tmp_path):
+    from data.evidence_cache_collector import collect_evidence_cache
+    from harness.authenticity import MoleculeEvidence, ReferenceEvidence
+
+    requirements = tmp_path / "requirements.csv"
+    cache_dir = tmp_path / "evidence_cache"
+    _requirements_csv(requirements)
+    _seed_caches(cache_dir)
+    reference_calls = []
+    molecule_calls = []
+
+    def reference_resolver(doi):
+        reference_calls.append(doi)
+        return ReferenceEvidence(
+            doi=doi,
+            title=f"Resolved {doi}",
+            year=2026,
+            journal="Journal of Physical Chemistry Letters",
+            source="fixture-crossref",
+            url=f"https://doi.org/{doi}",
+        )
+
+    def molecule_resolver(record):
+        molecule_calls.append(dict(record))
+        if record.get("pubchem_id") == "104810":
+            return MoleculeEvidence(
+                smiles="[Ba+2]",
+                pubchem_id="104810",
+                source="fixture-pubchem",
+                url="https://pubchem.ncbi.nlm.nih.gov/compound/104810",
+            )
+        return None
+
+    first = collect_evidence_cache(
+        requirements_csv=requirements,
+        cache_dir=cache_dir,
+        max_requests=2,
+        reference_resolver=reference_resolver,
+        molecule_resolver=molecule_resolver,
+    )
+
+    assert first["attempted_count"] == 2
+    assert first["remaining_missing_count"] == 2
+    assert reference_calls == ["10.1021/acs.jpclett.6c00119", "10.1038/s41586-026-00001-1"]
+    assert molecule_calls == []
+
+    second = collect_evidence_cache(
+        requirements_csv=requirements,
+        cache_dir=cache_dir,
+        max_requests=10,
+        reference_resolver=reference_resolver,
+        molecule_resolver=molecule_resolver,
+    )
+
+    assert second["attempted_count"] == 2
+    assert second["positive_written_count"] == 1
+    assert second["negative_written_count"] == 1
+    assert second["remaining_missing_count"] == 0
+    assert molecule_calls == [{"pubchem_id": "104810"}, {"smiles": "CCO"}]
+
+    reference_cache = json.loads((cache_dir / "reference_cache.json").read_text(encoding="utf-8"))
+    molecule_cache = json.loads((cache_dir / "molecule_cache.json").read_text(encoding="utf-8"))
+    assert reference_cache["10.1126/science.cached"]["title"] == "Already cached"
+    assert reference_cache["10.1021/acs.jpclett.6c00119"]["source"] == "fixture-crossref"
+    assert reference_cache["10.1038/s41586-026-00001-1"]["source"] == "fixture-crossref"
+    assert molecule_cache["pubchem:104810"]["pubchem_id"] == "104810"
+    assert molecule_cache["smiles:CCO"] is None
+
+
+def test_collector_dry_run_does_not_write_cache_files(tmp_path):
+    from data.evidence_cache_collector import collect_evidence_cache
+
+    requirements = tmp_path / "requirements.csv"
+    cache_dir = tmp_path / "evidence_cache"
+    _requirements_csv(requirements)
+    _seed_caches(cache_dir)
+    before = {
+        path.name: path.read_text(encoding="utf-8")
+        for path in (cache_dir / "reference_cache.json", cache_dir / "molecule_cache.json")
+    }
+
+    summary = collect_evidence_cache(
+        requirements_csv=requirements,
+        cache_dir=cache_dir,
+        max_requests=3,
+        dry_run=True,
+        reference_resolver=lambda doi: None,
+        molecule_resolver=lambda record: None,
+    )
+
+    assert summary["dry_run"] is True
+    assert summary["attempted_count"] == 0
+    assert summary["planned_count"] == 3
+    assert {
+        path.name: path.read_text(encoding="utf-8")
+        for path in (cache_dir / "reference_cache.json", cache_dir / "molecule_cache.json")
+    } == before
+
+
+def test_collector_cli_writes_report_with_injected_resolvers(tmp_path, monkeypatch):
+    import run_evidence_cache_collector as runner
+    from harness.authenticity import ReferenceEvidence
+
+    requirements = tmp_path / "requirements.csv"
+    cache_dir = tmp_path / "evidence_cache"
+    output_json = tmp_path / "collector_report.json"
+    _requirements_csv(requirements)
+    _seed_caches(cache_dir)
+
+    monkeypatch.setattr(
+        runner,
+        "CrossrefReferenceVerifier",
+        lambda: lambda doi: ReferenceEvidence(doi=doi, title="CLI resolved", source="fixture-crossref"),
+    )
+    monkeypatch.setattr(runner, "PubChemMoleculeVerifier", lambda: lambda record: None)
+
+    exit_code = runner.main(
+        [
+            "--requirements-csv",
+            str(requirements),
+            "--dataset-id",
+            "collector-cli",
+            "--cache-dir",
+            str(cache_dir),
+            "--max-requests",
+            "1",
+            "--output-json",
+            str(output_json),
+        ]
+    )
+
+    assert exit_code == 0
+    report = json.loads(output_json.read_text(encoding="utf-8"))
+    assert report["dataset_id"] == "collector-cli"
+    assert report["attempted_count"] == 1
+    assert report["entity_type_counts"]["reference"] == 1

--- a/tests/test_evidence_cache_collector.py
+++ b/tests/test_evidence_cache_collector.py
@@ -280,3 +280,53 @@ def test_collector_does_not_write_negative_cache_after_retry_exhaustion(tmp_path
     assert summary["error_count"] == 1
     reference_cache = json.loads((cache_dir / "reference_cache.json").read_text(encoding="utf-8"))
     assert "10.1021/acs.jpclett.6c00119" not in reference_cache
+
+
+def test_collector_does_not_write_negative_cache_for_none_by_default(tmp_path):
+    from data.evidence_cache_collector import collect_evidence_cache
+
+    requirements = tmp_path / "requirements.csv"
+    cache_dir = tmp_path / "evidence_cache"
+    _requirements_csv(requirements)
+    _seed_caches(cache_dir)
+
+    summary = collect_evidence_cache(
+        requirements_csv=requirements,
+        cache_dir=cache_dir,
+        max_requests=1,
+        reference_resolver=lambda doi: None,
+        molecule_resolver=lambda record: None,
+    )
+
+    assert summary["attempted_count"] == 1
+    assert summary["no_evidence_count"] == 1
+    assert summary["negative_written_count"] == 0
+    reference_cache = json.loads((cache_dir / "reference_cache.json").read_text(encoding="utf-8"))
+    assert "10.1021/acs.jpclett.6c00119" not in reference_cache
+
+
+def test_collector_never_writes_negative_cache_for_smiles_with_cid_only_resolver(tmp_path):
+    from data.evidence_cache_collector import collect_evidence_cache
+
+    requirements = tmp_path / "requirements.csv"
+    cache_dir = tmp_path / "evidence_cache"
+    _requirements_csv(requirements)
+    _seed_caches(cache_dir)
+
+    summary = collect_evidence_cache(
+        requirements_csv=requirements,
+        cache_dir=cache_dir,
+        max_requests=10,
+        entity_type="molecule",
+        include_smiles=True,
+        write_negative_cache=True,
+        reference_resolver=lambda doi: None,
+        molecule_resolver=lambda record: None,
+    )
+
+    assert summary["attempted_count"] == 2
+    assert summary["negative_written_count"] == 1
+    assert summary["no_evidence_count"] == 1
+    molecule_cache = json.loads((cache_dir / "molecule_cache.json").read_text(encoding="utf-8"))
+    assert molecule_cache["pubchem:104810"] is None
+    assert "smiles:CCO" not in molecule_cache


### PR DESCRIPTION
## Summary
- add a bounded, resumable external evidence cache collector that consumes preflight requirements CSVs
- add collector CLI and Makefile targets, including a dry-run target
- protect cache integrity: skip existing keys, skip unsupported SMILES fallback by default, retry resolver exceptions, and do not write resolver None as negative cache unless explicitly requested

## Verification
- RED: PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --with pytest python -m pytest -q tests/test_evidence_cache_collector.py tests/test_canonical_make_targets.py failed before implementation with missing module/CLI/targets
- GREEN: PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --with pytest python -m pytest -q tests/test_evidence_cache_collector.py tests/test_evidence_cache_preflight.py tests/test_evidence_cache_verifiers.py tests/test_run_verified_discovery_cli.py tests/test_research_package_runner.py tests/test_research_package_contract.py tests/test_canonical_make_targets.py -> 46 passed
- Lint: uv run --with ruff ruff check hybrid_agent_exploration/src/data/evidence_cache_collector.py hybrid_agent_exploration/src/run_evidence_cache_collector.py tests/test_evidence_cache_collector.py tests/test_canonical_make_targets.py -> All checks passed
- Real smoke dry-run: make research-package-cache-preflight-smoke ... DATASET_ID=collector-smoke-final then make research-package-cache-collect-dry-run ... CACHE_COLLECT_MAX_REQUESTS=3 -> attempted=0, remaining_missing=15

## Scientific note
This PR enables safe incremental cache collection toward an external-cached full-source package. It does not claim publication-grade closure until the caches are populated and package verification passes with REQUIRE_EVIDENCE_CACHE=1.