### PR TITLE
fix: declare SOCKS proxy support for evidence requests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "xgboost>=2.0.0",
     "lightgbm>=4.0.0",
     "pyyaml>=6.0.3",
+    "pysocks>=1.7.1",
 ]
 
 [build-system]

--- a/tests/test_project_dependencies.py
+++ b/tests/test_project_dependencies.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import tomllib
+import importlib.util
 from pathlib import Path
 
 
@@ -12,3 +13,11 @@ def test_pyproject_declares_yaml_dependency_for_plan_registry():
     dependencies = [dependency.lower() for dependency in pyproject["project"]["dependencies"]]
 
     assert any(dependency.startswith("pyyaml") for dependency in dependencies)
+
+
+def test_project_declares_socks_proxy_support_for_external_evidence_requests():
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    dependencies = [dependency.lower() for dependency in pyproject["project"]["dependencies"]]
+
+    assert any(dependency.startswith("pysocks") for dependency in dependencies)
+    assert importlib.util.find_spec("socks") is not None

--- a/uv.lock
+++ b/uv.lock
@@ -978,6 +978,7 @@ dependencies = [
     { name = "openpyxl" },
     { name = "pandas" },
     { name = "plotly" },
+    { name = "pysocks" },
     { name = "pyyaml" },
     { name = "requests" },
     { name = "scikit-learn" },
@@ -996,6 +997,7 @@ requires-dist = [
     { name = "openpyxl", specifier = ">=3.1.0" },
     { name = "pandas", specifier = ">=2.0.0" },
     { name = "plotly", specifier = ">=5.15.0" },
+    { name = "pysocks", specifier = ">=1.7.1" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "requests", specifier = ">=2.31.0" },
     { name = "scikit-learn", specifier = ">=1.3.0" },
@@ -1286,6 +1288,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pysocks"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/11/293dd436aea955d45fc4e8a35b6ae7270f5b8e00b53cf6c024c83b657a11/PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0", size = 284429, upload-time = "2019-09-20T02:07:35.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/59/b4572118e098ac8e46e399a1dd0f2d85403ce8bbaad9ec79373ed6badaf9/PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5", size = 16725, upload-time = "2019-09-20T02:06:22.938Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add PySocks to project dependencies so requests can use SOCKS proxy settings in this environment
- add dependency regression coverage for the socks module used by requests proxy support

## Verification
- RED: PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --with pytest python -m pytest -q tests/test_project_dependencies.py failed before dependency declaration
- GREEN: PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --with pytest python -m pytest -q tests/test_project_dependencies.py tests/test_evidence_cache_collector.py tests/test_evidence_cache_verifiers.py -> 15 passed
- Live evidence check: uv run python CrossrefReferenceVerifier for 10.1021/acs.jpclett.6c00119 and 10.1021/acsenergylett.3c01368 returned real Crossref evidence instead of Missing dependencies for SOCKS support

## Scientific note
This unblocks real external evidence cache collection in SOCKS-proxy environments; it does not by itself complete the publication-grade cache.