### PR TITLE
fix: write evidence cache reports atomically

### DIFF
--- a/hybrid_agent_exploration/src/data/evidence_cache_collector.py
+++ b/hybrid_agent_exploration/src/data/evidence_cache_collector.py
@@ -347,7 +347,7 @@ def _write_json_atomic(payload: dict[str, Any], path: Path) -> None:
             encoding="utf-8",
         )
         tmp_path.replace(path)
-    except Exception:
+    except BaseException:
         tmp_path.unlink(missing_ok=True)
         raise
 

--- a/hybrid_agent_exploration/src/data/evidence_cache_collector.py
+++ b/hybrid_agent_exploration/src/data/evidence_cache_collector.py
@@ -194,11 +194,7 @@ def write_collection_report(summary: dict[str, Any], output_path: str | Path) ->
     """Write the collector summary JSON."""
 
     path = Path(output_path)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
-        json.dumps(summary, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
+    _write_json_atomic(summary, path)
     return path
 
 
@@ -339,11 +335,21 @@ def _load_cache(path: Path) -> dict[str, Any]:
 
 
 def _write_cache(cache: dict[str, Any], path: Path) -> None:
+    _write_json_atomic(cache, path)
+
+
+def _write_json_atomic(payload: dict[str, Any], path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(
-        json.dumps(cache, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
+    tmp_path = path.with_name(f".{path.name}.tmp")
+    try:
+        tmp_path.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        tmp_path.replace(path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
 
 
 def _molecule_record(key: str) -> dict[str, Any]:

--- a/tests/test_evidence_cache_collector.py
+++ b/tests/test_evidence_cache_collector.py
@@ -484,3 +484,49 @@ def test_collector_progress_snapshot_cannot_mutate_final_summary(tmp_path):
     assert summary["processed"][0]["cache_status"] == "positive"
     assert summary["processed"][0]["record_ids"] == ["row-001", "row-002"]
     assert summary["entity_type_counts"] == {"reference": 1}
+
+
+def test_cache_write_failure_keeps_existing_json_readable(tmp_path, monkeypatch):
+    from data.evidence_cache_collector import _write_cache
+
+    cache_path = tmp_path / "reference_cache.json"
+    cache_path.write_text(json.dumps({"existing": {"title": "safe"}}), encoding="utf-8")
+    original_write_text = Path.write_text
+
+    def failing_write_text(path, text, *args, **kwargs):
+        original_write_text(path, '{"partial"', *args, **kwargs)
+        raise RuntimeError("simulated interrupted write")
+
+    monkeypatch.setattr(Path, "write_text", failing_write_text)
+
+    try:
+        _write_cache({"new": {"title": "unsafe"}}, cache_path)
+    except RuntimeError:
+        pass
+
+    assert json.loads(cache_path.read_text(encoding="utf-8")) == {
+        "existing": {"title": "safe"}
+    }
+
+
+def test_report_write_failure_keeps_existing_json_readable(tmp_path, monkeypatch):
+    from data.evidence_cache_collector import write_collection_report
+
+    report_path = tmp_path / "report.json"
+    report_path.write_text(json.dumps({"attempted_count": 1}), encoding="utf-8")
+    original_write_text = Path.write_text
+
+    def failing_write_text(path, text, *args, **kwargs):
+        original_write_text(path, '{"partial"', *args, **kwargs)
+        raise RuntimeError("simulated interrupted write")
+
+    monkeypatch.setattr(Path, "write_text", failing_write_text)
+
+    try:
+        write_collection_report({"attempted_count": 2}, report_path)
+    except RuntimeError:
+        pass
+
+    assert json.loads(report_path.read_text(encoding="utf-8")) == {
+        "attempted_count": 1
+    }

--- a/tests/test_evidence_cache_collector.py
+++ b/tests/test_evidence_cache_collector.py
@@ -528,3 +528,28 @@ def test_report_write_failure_keeps_existing_json_readable(tmp_path, monkeypatch
         pass
 
     assert json.loads(report_path.read_text(encoding="utf-8")) == {"attempted_count": 1}
+
+
+def test_atomic_write_cleans_temp_file_after_keyboard_interrupt(tmp_path, monkeypatch):
+    from data.evidence_cache_collector import _write_cache
+
+    cache_path = tmp_path / "reference_cache.json"
+    cache_path.write_text(json.dumps({"existing": {"title": "safe"}}), encoding="utf-8")
+    temp_path = cache_path.with_name(f".{cache_path.name}.tmp")
+    original_write_text = Path.write_text
+
+    def interrupted_write_text(path, text, *args, **kwargs):
+        original_write_text(path, '{"partial"', *args, **kwargs)
+        raise KeyboardInterrupt()
+
+    monkeypatch.setattr(Path, "write_text", interrupted_write_text)
+
+    try:
+        _write_cache({"new": {"title": "unsafe"}}, cache_path)
+    except KeyboardInterrupt:
+        pass
+
+    assert json.loads(cache_path.read_text(encoding="utf-8")) == {
+        "existing": {"title": "safe"}
+    }
+    assert not temp_path.exists()

--- a/tests/test_evidence_cache_collector.py
+++ b/tests/test_evidence_cache_collector.py
@@ -527,6 +527,4 @@ def test_report_write_failure_keeps_existing_json_readable(tmp_path, monkeypatch
     except RuntimeError:
         pass
 
-    assert json.loads(report_path.read_text(encoding="utf-8")) == {
-        "attempted_count": 1
-    }
+    assert json.loads(report_path.read_text(encoding="utf-8")) == {"attempted_count": 1}


### PR DESCRIPTION
## Summary
- write evidence cache JSON and collector report JSON through a temporary file followed by `replace()`
- keep existing readable JSON intact if a write is interrupted before the replace step
- clean up temporary files on failed writes

## Why
During the live external evidence-cache collection run, read-only monitoring occasionally caught cache files mid-write and `jq` saw partial JSON. The collector already resumes from cache, so cache/report writes should be atomic enough for long-running monitored batches.

## TDD / Verification
- RED: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --with pytest python -m pytest -q tests/test_evidence_cache_collector.py::test_cache_write_failure_keeps_existing_json_readable tests/test_evidence_cache_collector.py::test_report_write_failure_keeps_existing_json_readable` failed because current direct writes clobbered existing JSON with a partial payload.
- GREEN: same tests passed after atomic writes.
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --with pytest python -m pytest -q tests/test_canonical_make_targets.py tests/test_evidence_cache_collector.py tests/test_evidence_cache_preflight.py tests/test_research_package_runner.py tests/test_run_verified_discovery_cli.py tests/test_root_provenance_manifest.py` -> 39 passed
- `uv run ruff check hybrid_agent_exploration/src/data/evidence_cache_collector.py tests/test_evidence_cache_collector.py`
- `uv run ruff format --check hybrid_agent_exploration/src/data/evidence_cache_collector.py tests/test_evidence_cache_collector.py`
- `git diff --check origin/main...HEAD`
